### PR TITLE
An option is added that checks what is being executed and makes the c…

### DIFF
--- a/backend/designer.py
+++ b/backend/designer.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 from activity import Activity
@@ -57,5 +58,8 @@ def demo_frame(gpx_filename, template_filename, second, headless):
     scene.build_figures()
     scene.render_demo(end - start, second)
     if not headless:
-        subprocess.call(["open", scene.frames[0].full_path()])
+        if os.name == 'nt':
+            subprocess.call(["start", scene.frames[0].full_path()], shell=True)
+        else:
+            subprocess.call(["open", scene.frames[0].full_path()])
     return scene


### PR DESCRIPTION
An option is added that checks what is being executed and makes the correct call.
This is added because if the program is run on Windows the error occurs: `FileNotFoundError: [WinError 2] The system cannot find the file specified`
It happens because the `open `command does not exist in Windows.