### PR TITLE
Export format dialog with per-codec render estimates

### DIFF
--- a/app/src/api/backend.js
+++ b/app/src/api/backend.js
@@ -402,6 +402,10 @@ export const nativeGenerateDemoCrop = (
  * @param {string} [outputDir]
  * @param {number} [targetWidth]
  * @param {number} [targetHeight]
+ * @param {'prores' | 'qtrle' | 'stitched'} [exportFormat]
+ * @param {{videoPath: string, videoIn: number}} [stitch] — source footage for
+ *   a stitched export; videoIn is seconds into the footage where the overlay's
+ *   first frame lands
  * @returns {Promise<RenderStarted>}
  */
 export const nativeStartRender = (
@@ -410,6 +414,8 @@ export const nativeStartRender = (
   outputDir,
   targetWidth,
   targetHeight,
+  exportFormat,
+  stitch,
 ) =>
   invoke('native_render', {
     config,
@@ -417,6 +423,9 @@ export const nativeStartRender = (
     outputDir: outputDir ?? null,
     targetWidth: targetWidth ?? null,
     targetHeight: targetHeight ?? null,
+    exportFormat: exportFormat ?? null,
+    stitchVideoPath: stitch?.videoPath ?? null,
+    stitchVideoIn: stitch?.videoIn ?? null,
   })
 
 /** @returns {Promise<RenderProgress>} */
@@ -444,6 +453,35 @@ export const nativeBenchmark = (
     config,
     gpxFilename,
     frames,
+    targetWidth: targetWidth ?? null,
+    targetHeight: targetHeight ?? null,
+  })
+
+/**
+ * Short real export (render + FFmpeg encode) of the first few timeline
+ * seconds to a throwaway file — measures wall time and encoded size so
+ * time/size estimates reflect this machine and codec.
+ * @param {import('./elementTypes.js').Template} config
+ * @param {string} gpxFilename
+ * @param {'prores' | 'qtrle'} exportFormat
+ * @param {number} [seconds]
+ * @param {number} [targetWidth]
+ * @param {number} [targetHeight]
+ * @returns {Promise<{frames: number, elapsed_ms: number, bytes: number}>}
+ */
+export const nativeCalibrateExport = (
+  config,
+  gpxFilename,
+  exportFormat,
+  seconds,
+  targetWidth,
+  targetHeight,
+) =>
+  invoke('native_calibrate_export', {
+    config,
+    gpxFilename,
+    exportFormat,
+    seconds: seconds ?? null,
     targetWidth: targetWidth ?? null,
     targetHeight: targetHeight ?? null,
   })

--- a/app/src/api/renderVideo.js
+++ b/app/src/api/renderVideo.js
@@ -1,12 +1,20 @@
 import * as backend from './backend.js'
 import { exportBitsPerPixelSecond } from '../lib/utils.js'
+import { videoStartOnAxis } from '../lib/videoAlignment.js'
 
 const ETA_REANCHOR_MS = 30_000
 const ETA_MIN_SAMPLE_SECONDS = 5
 const ETA_MAX_UPWARD_ADJUST_SECONDS = 15
 
 export default async function renderVideo(state) {
-  const { config, gpxFilename, outputDir, outputWidth, outputHeight } = state
+  const {
+    config,
+    gpxFilename,
+    outputDir,
+    outputWidth,
+    outputHeight,
+    exportFormat,
+  } = state
   if (!config?.scene) throw new Error('No valid config available')
   if (!gpxFilename) throw new Error('No GPX file selected')
   const start = config.scene.start ?? 0
@@ -17,6 +25,31 @@ export default async function renderVideo(state) {
     )
 
   const fps = config.scene.fps ?? 30
+
+  // Stitched export: composite the overlay onto the reference video. The
+  // export window is the overlap of the scene range and the video's extent on
+  // the timeline, so the overlay and footage cover the same wall-clock span.
+  let renderConfig = config
+  let renderStart = start
+  let renderEnd = end
+  let stitch = null
+  if (exportFormat === 'stitched') {
+    const video = state.video
+    if (!video?.path || video.missing)
+      throw new Error('Stitched export needs a video — load one first')
+    const videoStart = videoStartOnAxis(state.gpxStartTime, video)
+    renderStart = Math.max(start, videoStart)
+    renderEnd = Math.min(end, videoStart + (video.duration ?? 0))
+    if (!(renderEnd > renderStart))
+      throw new Error(
+        'The export range does not overlap the video — adjust the timeline range or move the video on the timeline',
+      )
+    renderConfig = {
+      ...config,
+      scene: { ...config.scene, start: renderStart, end: renderEnd },
+    }
+    stitch = { videoPath: video.path, videoIn: renderStart - videoStart }
+  }
 
   state.renderProgress = {
     current: 0,
@@ -31,11 +64,13 @@ export default async function renderVideo(state) {
 
   try {
     const startData = await backend.nativeStartRender(
-      config,
+      renderConfig,
       gpxFilename,
       outputDir,
       outputWidth,
       outputHeight,
+      exportFormat,
+      stitch,
     )
     const outputPath = startData.output_path
 
@@ -111,9 +146,7 @@ export default async function renderVideo(state) {
             if (p.error) reject(new Error(p.error))
             else {
               if (p.frames_rendered > 0 && elapsed > 0) {
-                const fps = p.frames_rendered / elapsed
-                state.lastRenderFps = fps
-                localStorage.setItem('lastRenderFps', fps.toFixed(4))
+                state.recordRenderFps(exportFormat, p.frames_rendered / elapsed)
               }
               resolve()
             }
@@ -132,9 +165,9 @@ export default async function renderVideo(state) {
         outputWidth,
         outputHeight,
         fps,
-        end - start,
+        renderEnd - renderStart,
       )
-      state.recordExportSizeEstimate(bitsPerPixelSecond)
+      state.recordExportSizeEstimate(bitsPerPixelSecond, exportFormat)
     } catch {
       /* file-size calibration is best-effort */
     }

--- a/app/src/app.svelte
+++ b/app/src/app.svelte
@@ -12,6 +12,7 @@
   import CenterCanvas from './components/layout/CenterCanvas.svelte'
   import RightPanel from './components/layout/RightPanel.svelte'
   import RenderProgressOverlay from './components/overlays/RenderProgressOverlay.svelte'
+  import RenderStatusChip from './components/overlays/RenderStatusChip.svelte'
   import ErrorToast from './components/overlays/ErrorToast.svelte'
   import UpdateBanner from './components/overlays/UpdateBanner.svelte'
   import Settings from './components/overlays/Settings.svelte'
@@ -20,6 +21,7 @@
   import ActivityPickerModal from './components/overlays/ActivityPickerModal.svelte'
   import ConfirmDialog from './components/overlays/ConfirmDialog.svelte'
   import NewTemplateDialog from './components/overlays/NewTemplateDialog.svelte'
+  import ExportFormatDialog from './components/overlays/ExportFormatDialog.svelte'
   import Button from './components/ui/Button.svelte'
   import Tooltip from './components/ui/Tooltip.svelte'
 
@@ -39,7 +41,13 @@
     Sparkles,
     X,
   } from 'lucide-svelte'
-  import { formatTime, estimateProResFileSize, TOOLTIP_DELAY } from './lib/utils.js'
+  import {
+    formatTime,
+    estimateExportFileSize,
+    DEFAULT_BITS_PER_PIXEL_SECOND,
+    DEFAULT_STITCHED_BITS_PER_PIXEL_SECOND,
+    TOOLTIP_DELAY,
+  } from './lib/utils.js'
   import { wallClockApplicable } from './lib/videoAlignment.js'
 
   // ── State ──────────────────────────────────────────────────────────────────
@@ -64,6 +72,48 @@
     { label: '1080p Vertical', w: 1080, h: 1920 },
     { label: 'Square', w: 1080, h: 1080 },
   ]
+
+  // Export options: two transparent-overlay codecs (both .mov — ProRes 4444
+  // is smaller and hardware-accelerated but consumer editors like Premiere
+  // Elements on Windows can't decode it; Animation/qtrle is the compatible
+  // fallback), plus a stitched export that burns the overlay onto the
+  // reference video for a finished, shareable MP4. The stitched option only
+  // appears once a video is loaded — with no footage there's nothing to burn
+  // onto, so offering it would just dead-end into a file picker.
+  let hasVideoLoaded = $derived(!!app.video?.path && !app.video.missing)
+  let EXPORT_FORMATS = $derived([
+    {
+      value: 'prores',
+      label: 'ProRes 4444',
+      container: '.mov',
+      transparent: true,
+      bestFor: 'Pro editors',
+      summary: 'Transparent overlay for pro editors.',
+      desc: 'Overlay only, on a transparent background — layer it onto your own edit. Smaller files, but needs a pro editor: Premiere Pro, Final Cut, or DaVinci Resolve.',
+    },
+    {
+      value: 'qtrle',
+      label: 'Animation (RLE)',
+      container: '.mov',
+      transparent: true,
+      bestFor: 'Any editor',
+      summary: 'Transparent overlay that plays in any editor.',
+      desc: 'Overlay only, on a transparent background — plays in any editor, including ones without ProRes support like Premiere Elements on Windows. Slightly larger files.',
+    },
+    ...(hasVideoLoaded
+      ? [
+          {
+            value: 'stitched',
+            label: 'Video with overlay',
+            container: '.mp4',
+            transparent: false,
+            bestFor: 'Sharing',
+            summary: 'Overlay burned onto your video — ready to share.',
+            desc: `Burns the overlay directly onto ${videoBasename(app.video.path)} — a finished video, ready to share. No editor needed.`,
+          },
+        ]
+      : []),
+  ])
 
   // True when the user is in custom-resolution mode. Initialised to true when
   // the persisted dims don't match any preset (e.g. loaded from a prior session).
@@ -229,10 +279,18 @@
       showSettings ||
       app.showTemplatePicker ||
       showNewTemplateDialog ||
-      showActivityPicker
+      showActivityPicker ||
+      showExportFormatDialog
 
     if (e.key === 'Escape' && showResolutionMenu) {
       showResolutionMenu = false
+      return
+    }
+
+    // Escape minimizes the render dialog back to the header status chip
+    // (the render keeps running).
+    if (e.key === 'Escape' && app.renderingVideo && renderExpanded) {
+      renderExpanded = false
       return
     }
 
@@ -409,13 +467,60 @@
     }
   }
 
-  async function handleRender() {
+  // Render is a two-step flow: the button opens the export-format dialog,
+  // confirming there starts the actual render.
+  let showExportFormatDialog = $state(false)
+  // Whether the full render-progress dialog is open. Renders show the ambient
+  // header chip by default; expanding opens the dialog on demand.
+  let renderExpanded = $state(false)
+
+  function handleRender() {
     if (rendering || !app.hasActivity) return
+    showExportFormatDialog = true
+  }
+
+  // Measure any codec that has no same-machine numbers yet, one at a time
+  // (the native calibrator is single-flight). Bails if a real render starts.
+  async function warmUpExportEstimates() {
+    for (const f of EXPORT_FORMATS) {
+      if (app.renderingVideo) return
+      if (exportTestAvailableFor(f.value)) {
+        await app.calibrateExportEstimate(f.value)
+      }
+    }
+  }
+
+  // Warm up export estimates in the background, well before the user is likely
+  // to open the export dialog, so its cards already show real time & size
+  // numbers with no waiting. Re-arms whenever a new activity or template is
+  // loaded; exportTestAvailableFor goes false after a successful measurement,
+  // so an already-measured codec is skipped and this won't repeat needlessly.
+  const EXPORT_WARMUP_DELAY_MS = 2500
+  $effect(() => {
+    // Coarse triggers only — read the identity of what's loaded, not the
+    // deeply-reactive config, so template edits don't re-arm on every keystroke.
+    const ready = app.hasActivity
+    void app.loadedTemplateFilename
+    if (!ready) return
+    const timer = setTimeout(warmUpExportEstimates, EXPORT_WARMUP_DELAY_MS)
+    return () => clearTimeout(timer)
+  })
+
+  async function startRender(format) {
+    showExportFormatDialog = false
+    if (rendering || !app.hasActivity) return
+    if (format === 'stitched' && (!app.video?.path || app.video.missing)) {
+      // Stitching needs footage — pick it now; bail if the user cancels.
+      await app.pickAndLoadVideo()
+      if (!app.video?.path || app.video.missing) return
+    }
+    app.exportFormat = format
     if (!hasRenderedOnce) {
       hasRenderedOnce = true
       localStorage.setItem(RENDERED_ONCE_KEY, 'true')
     }
     rendering = true
+    renderExpanded = false
     try {
       const result = await renderVideo(app)
       if (result?.cancelled) console.log('Render cancelled')
@@ -437,33 +542,46 @@
   // Estimate render wall-clock time from the last recorded render FPS.
   // Re-evaluates whenever renderingVideo or config changes, so it picks up
   // the freshly-stored FPS right after a render finishes.
-  let renderEstimateSecs = $derived.by(() => {
+  function renderEstimateSecsFor(format) {
     if (app.renderingVideo || !app.config?.scene || !app.hasActivity)
       return null
     const fps = app.config.scene.fps ?? 30
     const start = app.config.scene.start ?? 0
     const end = app.config.scene.end ?? app.timelineDuration
     if (start >= end) return null
-    const renderFps = app.lastRenderFps
+    const renderFps = app.renderFpsFor(format)
     if (!renderFps || renderFps <= 0) return null
     return Math.round(((end - start) * fps) / renderFps)
-  })
+  }
 
-  let renderFileSizeEst = $derived.by(() => {
+  function renderFileSizeEstFor(format) {
     if (!app.config?.scene || !app.hasActivity) return null
     const fps = app.config.scene.fps ?? 30
     const start = app.config.scene.start ?? 0
     const end = app.config.scene.end ?? app.timelineDuration
     const duration = end - start
     if (duration <= 0) return null
-    return estimateProResFileSize(
+    const calibration = app.exportSizeCalibrationFor(format)
+    // qtrle (lossless RLE) has no reliable prior — its size swings wildly with
+    // overlay content, so it shows nothing and offers a quick test render
+    // instead. ProRes and stitched (H.264) both have solid built-in priors.
+    if (!calibration && format === 'qtrle') return null
+    const fallbackBps =
+      format === 'stitched'
+        ? DEFAULT_STITCHED_BITS_PER_PIXEL_SECOND
+        : DEFAULT_BITS_PER_PIXEL_SECOND
+    return estimateExportFileSize(
       app.outputWidth,
       app.outputHeight,
       fps,
       duration,
-      app.exportSizeCalibration,
+      calibration,
+      fallbackBps,
     )
-  })
+  }
+
+  let renderEstimateSecs = $derived(renderEstimateSecsFor(app.exportFormat))
+  let renderFileSizeEst = $derived(renderFileSizeEstFor(app.exportFormat))
 
   let renderTooltip = $derived.by(() => {
     if (!app.config) return 'Load a template first'
@@ -475,6 +593,33 @@
     if (renderFileSizeEst != null) lines.push(`~${renderFileSizeEst} output`)
     return lines.length > 0 ? lines.join('\n') : null
   })
+
+  // Per-card estimates for the export dialog — render time and file size as
+  // separate labeled fields, so the codecs compare at a glance without
+  // clicking between them.
+  function exportTimeEstimateFor(format) {
+    const secs = renderEstimateSecsFor(format)
+    return secs != null ? `~${formatTime(secs)}` : null
+  }
+
+  function exportSizeEstimateFor(format) {
+    const size = renderFileSizeEstFor(format)
+    return size != null ? `~${size}` : null
+  }
+
+  // A codec with no same-machine measurement gets a "quick test" offer on its
+  // card instead of estimates derived from the other codec. Stitched is
+  // excluded: a test render can't include the source footage, so its numbers
+  // only come from real exports.
+  function exportTestAvailableFor(format) {
+    if (format === 'stitched') return false
+    if (!app.hasActivity || !app.config?.scene || app.renderingVideo)
+      return false
+    return (
+      renderEstimateSecsFor(format) == null ||
+      renderFileSizeEstFor(format) == null
+    )
+  }
 
   let gpxLabel = $derived.by(() => {
     if (!app.gpxFilename) return 'Load Activity'
@@ -501,7 +646,11 @@
 >
   <ErrorToast />
   <UpdateBanner />
-  <RenderProgressOverlay />
+  <RenderProgressOverlay
+    expanded={renderExpanded}
+    format={EXPORT_FORMATS.find((f) => f.value === app.exportFormat) ?? null}
+    onminimize={() => (renderExpanded = false)}
+  />
   {#if showSettings}
     <Settings
       onclose={() => {
@@ -524,6 +673,23 @@
       onload={loadActivityFromPickerOrMenu}
       onclose={() => {
         showActivityPicker = false
+      }}
+    />
+  {/if}
+  {#if showExportFormatDialog}
+    <ExportFormatDialog
+      formats={EXPORT_FORMATS}
+      initial={EXPORT_FORMATS.some((f) => f.value === app.exportFormat)
+        ? app.exportFormat
+        : EXPORT_FORMATS[0].value}
+      timeFor={exportTimeEstimateFor}
+      sizeFor={exportSizeEstimateFor}
+      testAvailableFor={exportTestAvailableFor}
+      calibrating={app.calibratingFormat}
+      oncalibrate={(fmt) => app.calibrateExportEstimate(fmt)}
+      onconfirm={startRender}
+      oncancel={() => {
+        showExportFormatDialog = false
       }}
     />
   {/if}
@@ -634,7 +800,11 @@
         </Tooltip>
 
         <!-- Revert to last saved -->
-        <Tooltip content="Revert to last saved" side="bottom" delay={TOOLTIP_DELAY}>
+        <Tooltip
+          content="Revert to last saved"
+          side="bottom"
+          delay={TOOLTIP_DELAY}
+        >
           <button
             onclick={handleRevertClick}
             class="hdr-btn hdr-btn-icon shrink-0"
@@ -649,7 +819,8 @@
             onclick={overwriteRepoTemplate}
             class="hdr-btn hdr-btn-icon shrink-0 border-sky-500/60 bg-sky-500/10 text-sky-400
                    hover:border-sky-400 hover:bg-sky-500/20 hover:text-sky-300 cursor-pointer"
-          >⬆</button>
+            >⬆</button
+          >
         </Tooltip>
       {/if}
     </div>
@@ -687,7 +858,11 @@
       </Tooltip>
     {:else if app.video.missing}
       <div class="flex items-center gap-1 shrink-0">
-        <Tooltip content="Locate replacement video" side="bottom" delay={TOOLTIP_DELAY}>
+        <Tooltip
+          content="Locate replacement video"
+          side="bottom"
+          delay={TOOLTIP_DELAY}
+        >
           <button
             onclick={() => app.pickAndLoadVideo()}
             class="hdr-btn px-2.5 gap-1.5 max-w-[160px] border-red-800/60 text-red-300 hover:border-red-600/60 hover:bg-red-900/30 hover:text-red-200"
@@ -711,7 +886,9 @@
             title={app.video.path}
           >
             <Film size={12} class="text-zinc-500 shrink-0" />
-            <span class="truncate text-zinc-200">{videoBasename(app.video.path)}</span>
+            <span class="truncate text-zinc-200"
+              >{videoBasename(app.video.path)}</span
+            >
           </button>
         </Tooltip>
         {#if canUseRecordingTime}
@@ -722,14 +899,21 @@
           >
         {/if}
         <Tooltip
-          content={app.videoUnderlayVisible ? 'Hide video underlay' : 'Show video underlay'}
+          content={app.videoUnderlayVisible
+            ? 'Hide video underlay'
+            : 'Show video underlay'}
           side="bottom"
           delay={TOOLTIP_DELAY}
         >
           <button
-            onclick={() => app.setVideoUnderlayVisible(!app.videoUnderlayVisible)}
-            class="hdr-btn hdr-btn-icon shrink-0 {app.videoUnderlayVisible ? '' : 'text-zinc-500'}"
-            aria-label={app.videoUnderlayVisible ? 'Hide video underlay' : 'Show video underlay'}
+            onclick={() =>
+              app.setVideoUnderlayVisible(!app.videoUnderlayVisible)}
+            class="hdr-btn hdr-btn-icon shrink-0 {app.videoUnderlayVisible
+              ? ''
+              : 'text-zinc-500'}"
+            aria-label={app.videoUnderlayVisible
+              ? 'Hide video underlay'
+              : 'Show video underlay'}
             aria-pressed={app.videoUnderlayVisible}
           >
             {#if app.videoUnderlayVisible}
@@ -754,7 +938,11 @@
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <!-- svelte-ignore a11y_click_events_have_key_events -->
       <div class="relative shrink-0" onclick={(e) => e.stopPropagation()}>
-        <Tooltip content="Choose output resolution" side="bottom" delay={TOOLTIP_DELAY}>
+        <Tooltip
+          content="Choose output resolution"
+          side="bottom"
+          delay={TOOLTIP_DELAY}
+        >
           <button
             type="button"
             onclick={() => {
@@ -882,22 +1070,26 @@
 
     <div class="flex-1"></div>
 
-    <!-- Render button -->
+    <!-- Render button / ambient render status -->
     <div class="flex items-center gap-2">
-      <Tooltip content={renderTooltip} side="bottom" align="end">
-        <Button
-          onclick={handleRender}
-          disabled={!app.config || !app.hasActivity || app.renderingVideo}
-          class="gap-1.5 min-w-[104px] border border-primary/70 bg-primary/15 text-zinc-100 hover:border-primary hover:bg-primary/25 {onboardingStep ===
-            0 && !hasRenderedOnce
-            ? 'onboarding-glow'
-            : ''}"
-          size="sm"
-        >
-          <Play size={13} />
-          {app.renderingVideo ? 'Rendering…' : 'Render Video'}
-        </Button>
-      </Tooltip>
+      {#if app.renderingVideo}
+        <RenderStatusChip onexpand={() => (renderExpanded = true)} />
+      {:else}
+        <Tooltip content={renderTooltip} side="bottom" align="end">
+          <Button
+            onclick={handleRender}
+            disabled={!app.config || !app.hasActivity}
+            class="gap-1.5 min-w-[104px] border border-primary/70 bg-primary/15 text-zinc-100 hover:border-primary hover:bg-primary/25 {onboardingStep ===
+              0 && !hasRenderedOnce
+              ? 'onboarding-glow'
+              : ''}"
+            size="sm"
+          >
+            <Play size={13} />
+            Render Video
+          </Button>
+        </Tooltip>
+      {/if}
     </div>
   </header>
 
@@ -907,7 +1099,7 @@
       <LeftSidebar />
     {/if}
     <CenterCanvas onopenactivity={handleOpenGpx} />
-    {#if app.config && app.hasActivity || showAiChat}
+    {#if (app.config && app.hasActivity) || showAiChat}
       <RightPanel
         aiChatOpen={showAiChat}
         onreopenAiChat={() => (showAiChat = true)}

--- a/app/src/components/canvas/VideoBackdrop.svelte
+++ b/app/src/components/canvas/VideoBackdrop.svelte
@@ -121,12 +121,11 @@
   <video
     bind:this={videoEl}
     {src}
-    muted
     playsinline
     preload="auto"
     ontimeupdate={onTimeupdate}
     onerror={onVideoError}
-    class="absolute inset-0 w-full h-full object-cover pointer-events-none rounded-lg"
+    class="absolute inset-0 w-full h-full object-contain pointer-events-none rounded-lg"
     style:visibility={inRange ? 'visible' : 'hidden'}
   ></video>
 {/if}

--- a/app/src/components/overlays/ExportFormatDialog.svelte
+++ b/app/src/components/overlays/ExportFormatDialog.svelte
@@ -1,0 +1,202 @@
+<script>
+  import { onMount } from 'svelte'
+
+  let {
+    // [{ value, label, container, transparent, desc }] — available export formats.
+    formats = [],
+    // Preselected format (last used, persisted)
+    initial = 'prores',
+    // (format) => "~1:20" | null — estimated render wall-clock time
+    timeFor = null,
+    // (format) => "~1.5 GB" | null — estimated output file size
+    sizeFor = null,
+    // (format) => boolean — true when the codec has no same-machine
+    // measurement yet, so it offers a quick test render
+    testAvailableFor = null,
+    // Format currently being measured by the test render, or null
+    calibrating = null,
+    // (format) => void — run the quick test render for a codec
+    oncalibrate = null,
+    onconfirm,
+    oncancel,
+  } = $props()
+
+  let selected = $state(initial)
+  let selectedFormat = $derived(formats.find((f) => f.value === selected))
+
+  // Shared column layout so the header cells and every row align.
+  const COLS =
+    'grid grid-cols-[1fr_6rem_5rem_4.5rem_5rem] items-center gap-2'
+
+  onMount(() => {
+    window.addEventListener('keydown', onKeydown)
+    return () => window.removeEventListener('keydown', onKeydown)
+  })
+
+  function onKeydown(e) {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      oncancel?.()
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      if (!calibrating) onconfirm?.(selected)
+    }
+  }
+</script>
+
+<div
+  role="dialog"
+  aria-modal="true"
+  aria-label="Choose export format"
+  tabindex="-1"
+  class="fixed inset-0 z-[60] flex items-center justify-center pt-14"
+  onmousedown={(e) => {
+    if (e.target === e.currentTarget) oncancel?.()
+  }}
+>
+  <div class="absolute inset-0 bg-black/60 backdrop-blur-sm"></div>
+
+  <div
+    class="relative z-10 w-[600px] rounded-xl border border-zinc-700 bg-zinc-900 shadow-2xl p-5"
+  >
+    <p class="text-base font-semibold text-zinc-100">Select export format</p>
+
+    <!-- Comparison table: transparency, render time, and file size side by
+         side so the formats are easy to weigh against each other. -->
+    <div
+      class="mt-3 rounded-[6px] border border-zinc-700 overflow-hidden"
+      role="radiogroup"
+      aria-label="Export format"
+    >
+      <div
+        class="{COLS} px-3 py-2 bg-zinc-800/60 border-b border-zinc-700
+               text-xs font-medium uppercase tracking-wide text-zinc-500"
+      >
+        <span>Format</span>
+        <span>Best for</span>
+        <span class="text-center">Transparent</span>
+        <span class="text-right">Est. time</span>
+        <span class="text-right">Est. size</span>
+      </div>
+
+      {#each formats as f, i (f.value)}
+        {@const active = selected === f.value}
+        {@const time = timeFor?.(f.value) ?? null}
+        {@const size = sizeFor?.(f.value) ?? null}
+        {@const measuring = calibrating === f.value}
+        {@const needsTest =
+          time == null && size == null && testAvailableFor?.(f.value)}
+        <div
+          role="radio"
+          aria-checked={active}
+          tabindex="0"
+          onclick={() => (selected = f.value)}
+          onkeydown={(e) => {
+            if (e.key === ' ') {
+              e.preventDefault()
+              selected = f.value
+            }
+          }}
+          class="{COLS} px-3 py-2.5 cursor-pointer transition-colors {i > 0
+            ? 'border-t border-zinc-800'
+            : ''} {active
+            ? 'bg-primary/10'
+            : 'bg-zinc-800/20 hover:bg-zinc-800/50'}"
+        >
+          <span class="flex items-baseline gap-1.5 min-w-0">
+            <span
+              class="truncate text-xs font-medium {active
+                ? 'text-zinc-50'
+                : 'text-zinc-200'}">{f.label}</span
+            >
+            {#if f.container}
+              <span class="shrink-0 font-mono text-xs text-zinc-600"
+                >{f.container}</span
+              >
+            {/if}
+          </span>
+
+          <span
+            class="truncate text-xs {active
+              ? 'text-zinc-300'
+              : 'text-zinc-400'}">{f.bestFor ?? ''}</span
+          >
+
+          <span
+            class="text-center font-mono text-xs {f.transparent
+              ? active
+                ? 'text-zinc-300'
+                : 'text-zinc-500'
+              : 'text-zinc-600'}">{f.transparent ? 'Yes' : 'No'}</span
+          >
+
+          {#if measuring}
+            <span
+              class="col-span-2 text-right font-mono text-xs text-zinc-400 animate-pulse"
+              >Testing…</span
+            >
+          {:else if needsTest}
+            {#if calibrating}
+              <span
+                class="col-span-2 text-right font-mono text-xs text-zinc-500"
+                >Queued…</span
+              >
+            {:else}
+              <button
+                type="button"
+                onclick={(e) => {
+                  e.stopPropagation()
+                  oncalibrate?.(f.value)
+                }}
+                class="col-span-2 text-right font-mono text-xs text-zinc-400
+                       underline decoration-zinc-600 underline-offset-2
+                       hover:text-zinc-200 cursor-pointer transition-colors"
+              >
+                Test render →
+              </button>
+            {/if}
+          {:else}
+            <span
+              class="text-right font-mono text-xs tabular-nums {active
+                ? 'text-zinc-200'
+                : 'text-zinc-400'}">{time ?? '—'}</span
+            >
+            <span
+              class="text-right font-mono text-xs tabular-nums {active
+                ? 'text-zinc-200'
+                : 'text-zinc-400'}">{size ?? '—'}</span
+            >
+          {/if}
+        </div>
+      {/each}
+    </div>
+
+    <!-- Detail for the selected format — keeps the table rows scannable while
+         still explaining what the choice means. -->
+    {#if selectedFormat?.desc}
+      <p class="mt-3 text-sm leading-relaxed text-zinc-400">
+        {selectedFormat.desc}
+      </p>
+    {/if}
+
+    <div class="mt-4 flex justify-end gap-2">
+      <button
+        onclick={() => oncancel?.()}
+        class="text-xs px-3 py-1.5 rounded border border-zinc-600 text-zinc-300
+               hover:border-zinc-400 hover:text-zinc-100 cursor-pointer transition-colors"
+      >
+        Cancel
+      </button>
+      <button
+        onclick={() => onconfirm?.(selected)}
+        disabled={!!calibrating}
+        title={calibrating ? 'Waiting for the test render to finish' : null}
+        class="text-xs px-3 py-1.5 rounded border border-primary/70 bg-primary/15 text-zinc-100
+               hover:border-primary hover:bg-primary/25 cursor-pointer transition-colors
+               disabled:opacity-50 disabled:cursor-default"
+      >
+        Render
+      </button>
+    </div>
+  </div>
+</div>

--- a/app/src/components/overlays/RenderProgressOverlay.svelte
+++ b/app/src/components/overlays/RenderProgressOverlay.svelte
@@ -3,9 +3,16 @@
   import { formatTime } from '@/lib/utils.js'
   import * as backend from '@/api/backend.js'
   import Button from '@/components/ui/Button.svelte'
-  import { CircleStop } from 'lucide-svelte'
+  import { CircleStop, Minimize2 } from 'lucide-svelte'
+
+  // Full render-progress dialog. Not shown by default — the header
+  // RenderStatusChip is the ambient status; this opens only when the user
+  // expands it, and `onminimize` collapses back to the chip.
+  let { expanded = false, format = null, onminimize } = $props()
 
   const app = getContext('app')
+
+  let fps = $derived(app.config?.scene?.fps ?? 30)
 
   let cancelling = $state(false)
 
@@ -35,9 +42,9 @@
   )
 </script>
 
-{#if app.renderingVideo}
+{#if app.renderingVideo && expanded}
   <div class="fixed inset-0 z-[100] flex items-center justify-center bg-zinc-950/90 backdrop-blur-md">
-    <div class="w-full max-w-sm rounded-xl border border-zinc-800 bg-zinc-900 p-8 shadow-2xl space-y-5">
+    <div class="relative w-full max-w-sm rounded-xl border border-zinc-800 bg-zinc-900 p-8 shadow-2xl space-y-5">
       <!-- Icon -->
       <div class="flex flex-col items-center gap-3 text-center">
         <div class="relative w-14 h-14 rounded-full bg-primary/10 flex items-center justify-center">
@@ -50,24 +57,42 @@
           </svg>
         </div>
         <div>
-          <h2 class="text-lg font-semibold">{finalizing ? 'Finalizing Video' : 'Generating Video'}</h2>
-          <p class="text-xs text-zinc-500 mt-0.5">
+          <h2 class="text-xl font-semibold">{finalizing ? 'Finalizing Video' : 'Generating Video'}</h2>
+          <p class="text-sm text-zinc-400 mt-1">
             {finalizing ? 'Encoding output file…' : `${formatTime(p.overlaySecondsRendered)} / ${formatTime(p.overlayTotalSeconds)} of overlay rendered`}
           </p>
         </div>
       </div>
 
+      <!-- Export format details -->
+      {#if format}
+        <div class="rounded-lg border border-zinc-800 bg-zinc-800/30 p-3 space-y-2">
+          <div class="flex items-center justify-between gap-2">
+            <span class="text-sm font-medium text-zinc-200">{format.label}</span>
+            <span class="text-[11px] font-mono text-zinc-400 rounded border border-zinc-700 px-1.5 py-0.5">{format.container}</span>
+          </div>
+          <p class="text-xs text-zinc-500 leading-relaxed">{format.summary ?? format.desc}</p>
+          <div class="flex flex-wrap items-center gap-1.5 pt-0.5 text-[11px] font-mono text-zinc-400">
+            <span>{app.outputWidth}×{app.outputHeight}</span>
+            <span class="text-zinc-700">·</span>
+            <span>{fps} fps</span>
+            <span class="text-zinc-700">·</span>
+            <span>{format.transparent ? 'Transparent' : 'Opaque'}</span>
+          </div>
+        </div>
+      {/if}
+
       <!-- Progress bar -->
       <div>
-        <div class="flex justify-between text-[11px] mb-1.5">
+        <div class="flex justify-between text-xs mb-1.5">
           <span class="text-primary font-medium">{pct}%</span>
           {#if estimating}
-            <span class="text-zinc-500 font-mono inline-flex items-center gap-1">
-              <span class="h-2 w-2 rounded-full border border-zinc-500 border-t-transparent animate-spin"></span>
+            <span class="text-zinc-400 font-mono inline-flex items-center gap-1">
+              <span class="h-2 w-2 rounded-full border border-zinc-400 border-t-transparent animate-spin"></span>
               estimating…
             </span>
           {:else if !finalizing && p.estimatedSecondsRemaining != null}
-            <span class="text-zinc-500 font-mono">{formatTime(p.estimatedSecondsRemaining)} remaining</span>
+            <span class="text-zinc-400 font-mono">{formatTime(p.estimatedSecondsRemaining)} remaining</span>
           {/if}
         </div>
         <div class="h-1.5 w-full rounded-full bg-zinc-800 overflow-hidden">
@@ -78,8 +103,17 @@
         </div>
       </div>
 
-      <!-- Cancel -->
-      <div class="flex justify-center">
+      <!-- Actions -->
+      <div class="flex justify-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onclick={() => onminimize?.()}
+          class="min-w-28 border-zinc-700 text-zinc-300 hover:border-zinc-600 hover:bg-zinc-800"
+        >
+          <Minimize2 size={13} />
+          Continue editing
+        </Button>
         <Button
           variant="outline"
           size="sm"
@@ -92,7 +126,7 @@
         </Button>
       </div>
 
-      <p class="text-[10px] text-center text-zinc-700 italic">Keep the app open during rendering</p>
+      <p class="text-xs text-center text-zinc-500 italic">Keep the app open during rendering</p>
     </div>
   </div>
 {/if}

--- a/app/src/components/overlays/RenderStatusChip.svelte
+++ b/app/src/components/overlays/RenderStatusChip.svelte
@@ -1,0 +1,57 @@
+<script>
+  import { getContext } from 'svelte'
+  import { formatTime } from '@/lib/utils.js'
+
+  // Compact render-status chip that lives in the header next to the Render
+  // button while a render runs in the background. Click to open the full
+  // progress dialog (the only place to cancel); the render keeps going either way.
+  let { onexpand } = $props()
+
+  const app = getContext('app')
+
+  let p = $derived(app.renderProgress)
+  let pct = $derived(p.total > 0 ? Math.round((p.current / p.total) * 100) : 0)
+  let finalizing = $derived(pct >= 100)
+  let estimating = $derived(
+    !finalizing &&
+      p.status === 'rendering' &&
+      p.estimatedSecondsRemaining == null,
+  )
+
+  // Progress-ring geometry.
+  const R = 9
+  const CIRC = 2 * Math.PI * R
+  let dashOffset = $derived(CIRC * (1 - Math.min(pct, 100) / 100))
+
+  let detail = $derived(
+    finalizing
+      ? 'Encoding output file…'
+      : estimating
+        ? 'Estimating time remaining…'
+        : p.estimatedSecondsRemaining != null
+          ? `${formatTime(p.estimatedSecondsRemaining)} remaining`
+          : `${formatTime(p.overlaySecondsRendered)} / ${formatTime(p.overlayTotalSeconds)} rendered`,
+  )
+</script>
+
+<button
+  type="button"
+  title={`${finalizing ? 'Finalizing' : `Rendering — ${pct}%`} · ${detail}\nClick for details`}
+  onclick={onexpand}
+  class="flex items-center h-7 rounded-[6px] border border-primary/40 bg-primary/10 px-2 gap-1.5 hover:border-primary/70 hover:bg-primary/15 transition-colors cursor-pointer"
+>
+  <!-- Progress ring -->
+  <span class="relative grid h-4 w-4 place-items-center">
+    <svg class="h-4 w-4 -rotate-90" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r={R} fill="none" stroke="currentColor" stroke-width="3" class="text-primary/25" />
+      {#if finalizing}
+        <circle cx="12" cy="12" r={R} fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" class="text-primary origin-center animate-spin" stroke-dasharray={`${CIRC * 0.25} ${CIRC}`} />
+      {:else}
+        <circle cx="12" cy="12" r={R} fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" class="text-primary transition-all duration-300" stroke-dasharray={CIRC} stroke-dashoffset={dashOffset} />
+      {/if}
+    </svg>
+  </span>
+  <span class="text-xs font-medium text-zinc-100 tabular-nums">
+    {finalizing ? 'Finalizing…' : `Rendering ${pct}%`}
+  </span>
+</button>

--- a/app/src/lib/utils.js
+++ b/app/src/lib/utils.js
@@ -45,23 +45,31 @@ export function exportBitsPerPixelSecond(
 // Midpoint guess for never-rendered sparse cycling overlays on ProRes 4444.
 // Real content lives in a wide band (~0.25–0.8); after a single render the
 // calibrated value supersedes this.
-const DEFAULT_BITS_PER_PIXEL_SECOND = 0.5
+export const DEFAULT_BITS_PER_PIXEL_SECOND = 0.5
 
-// ProRes 4444 is content-dependent, but a wide range is more noise than signal
-// in a tooltip — return a single best-guess number and let calibration sharpen
-// it as renders accumulate. `calibration` is { bps, n } or null.
-export function estimateProResFileSize(
+// Stitched (H.264) prior — matches the encoder's own bitrate target of
+// w·h·fps·0.12 bits/sec (see stitched_quality_args in render/scene.rs), so the
+// estimate lines up with what videotoolbox actually produces before any real
+// export has calibrated it.
+export const DEFAULT_STITCHED_BITS_PER_PIXEL_SECOND = 0.12
+
+// Codec output is content-dependent, but a wide range is more noise than
+// signal in a tooltip — return a single best-guess number and let calibration
+// sharpen it as renders accumulate. `calibration` is { bps, n } or null,
+// already resolved for the chosen export format by the caller; `fallbackBps`
+// is the prior to use until then.
+export function estimateExportFileSize(
   width,
   height,
   fps,
   durationSecs,
   calibration = null,
+  fallbackBps = DEFAULT_BITS_PER_PIXEL_SECOND,
 ) {
   const pixelsPerExport = width * height * fps * durationSecs
   if (!(pixelsPerExport > 0)) return null
-  const bps =
-    calibration?.bps > 0 ? calibration.bps : DEFAULT_BITS_PER_PIXEL_SECOND
-  return `~${formatFileSize((pixelsPerExport * bps) / 8)}`
+  const bps = calibration?.bps > 0 ? calibration.bps : fallbackBps
+  return formatFileSize((pixelsPerExport * bps) / 8)
 }
 
 // Native file-open dialog filters match extensions case-sensitively on some

--- a/app/src/state/appState.svelte.js
+++ b/app/src/state/appState.svelte.js
@@ -1,6 +1,10 @@
 import { open } from '@tauri-apps/plugin-dialog'
 import * as backend from '../api/backend.js'
-import { parseLocalStorage, dialogExtensions } from '../lib/utils.js'
+import {
+  parseLocalStorage,
+  dialogExtensions,
+  exportBitsPerPixelSecond,
+} from '../lib/utils.js'
 import { elementTypeName } from '../lib/elementTypes.js'
 import { stripDefaults } from '../lib/stripDefaults.js'
 import { normalizeElementUpdates } from '../lib/templateSchema.js'
@@ -19,17 +23,31 @@ if (import.meta.env.DEV && sessionStorage.getItem('dev_reset') === '1') {
 // ProRes 4444 bitrate varies wildly with overlay density, so calibration is
 // keyed by template. The empty-string slot is the cross-template fallback used
 // before a given template has been rendered.
+
+// Timeline seconds rendered by the export-estimate test render — long enough
+// to amortize FFmpeg/cache startup, short enough to stay a "quick test".
+const CALIBRATION_SECONDS = 4
+
 function loadExportSizeCalibration() {
   const empty = { templates: {} }
   const stored = parseLocalStorage('exportSizeCalibration')
-  if (stored && typeof stored === 'object' && stored.templates) return stored
+  if (stored && typeof stored === 'object' && stored.templates) {
+    // Migrate v1 per-template entries ({ bps, n }) to per-format
+    // ({ prores: { bps, n } }) — all pre-format-picker renders were ProRes.
+    const templates = {}
+    for (const [key, val] of Object.entries(stored.templates)) {
+      templates[key] = val?.bps > 0 ? { prores: val } : val
+    }
+    return { templates }
+  }
 
   // Migrate the pre-per-template single-value key, if present.
   const legacy = parseFloat(
     localStorage.getItem('exportSizeBitsPerPixelSecond') ?? '',
   )
   localStorage.removeItem('exportSizeBitsPerPixelSecond')
-  if (legacy > 0) return { templates: { '': { bps: legacy, n: 1 } } }
+  if (legacy > 0)
+    return { templates: { '': { prores: { bps: legacy, n: 1 } } } }
   return empty
 }
 
@@ -93,6 +111,10 @@ export function createAppState() {
   let outputHeight = $state(
     parseInt(localStorage.getItem('outputHeight') ?? '2160'),
   )
+  // Export format: 'prores' (ProRes 4444, default) or 'qtrle' (QuickTime
+  // Animation), both transparent-overlay .mov files; or 'stitched' — an H.264
+  // .mp4 with the overlay composited onto the reference video.
+  let exportFormat = $state(localStorage.getItem('exportFormat') ?? 'prores')
   // Snapshot of `config` as it was last loaded/saved. Used to detect unsaved
   // template edits. Output resolution lives outside `config`, so switching a
   // 1080p template into a 4K view never marks it modified.
@@ -111,6 +133,10 @@ export function createAppState() {
   let lastRenderFps = $state(
     parseFloat(localStorage.getItem('lastRenderFps') ?? '') || null,
   )
+  // Wall-clock render throughput from real exports, keyed by codec — qtrle's
+  // software encode can pace differently than hardware ProRes. `lastRenderFps`
+  // stays the codec-agnostic fallback (benchmarks measure render-only).
+  let renderFpsByFormat = $state(parseLocalStorage('renderFpsByFormat') ?? {})
   let exportSizeCalibration = $state(loadExportSizeCalibration())
   let renderingVideo = $state(false)
   let currentPreviewImage = $state(null) // data:image/png;base64,... from latest preview frame
@@ -179,6 +205,9 @@ export function createAppState() {
     localStorage.setItem('outputHeight', String(outputHeight))
   })
   $effect(() => {
+    localStorage.setItem('exportFormat', exportFormat)
+  })
+  $effect(() => {
     if (pristineConfig != null)
       localStorage.setItem('pristineConfig', pristineConfig)
     else localStorage.removeItem('pristineConfig')
@@ -191,6 +220,9 @@ export function createAppState() {
       'exportSizeCalibration',
       JSON.stringify(exportSizeCalibration),
     )
+  })
+  $effect(() => {
+    localStorage.setItem('renderFpsByFormat', JSON.stringify(renderFpsByFormat))
   })
 
   function templateSnapshot(value) {
@@ -349,28 +381,113 @@ export function createAppState() {
     return { bps: prev.bps * (1 - alpha) + sample * alpha, n: nextN }
   }
 
-  function recordExportSizeEstimate(actualBitsPerPixelSecond) {
+  function calibrationFormat(format) {
+    if (format === 'qtrle' || format === 'stitched') return format
+    return 'prores'
+  }
+
+  function recordExportSizeEstimate(actualBitsPerPixelSecond, format) {
     if (!(actualBitsPerPixelSecond >= MIN_VALID_BPS)) return
     if (!(actualBitsPerPixelSecond <= MAX_VALID_BPS)) return
+    const fmt = calibrationFormat(format ?? exportFormat)
     const key = loadedTemplateFilename ?? ''
     const templates = exportSizeCalibration.templates ?? {}
+    const blend = (slot) => ({
+      ...slot,
+      [fmt]: blendCalibration(slot?.[fmt], actualBitsPerPixelSecond),
+    })
     exportSizeCalibration = {
       templates: {
         ...templates,
-        [key]: blendCalibration(templates[key], actualBitsPerPixelSecond),
+        [key]: blend(templates[key]),
         // The empty-key slot doubles as the cross-template fallback used for
         // never-rendered templates.
-        ...(key === ''
-          ? {}
-          : { '': blendCalibration(templates[''], actualBitsPerPixelSecond) }),
+        ...(key === '' ? {} : { '': blend(templates['']) }),
       },
     }
   }
 
-  function currentExportSizeCalibration() {
+  // Size calibration comes only from real exports (or the quick test render)
+  // in the same codec — the qtrle/ProRes ratio varies too much with overlay
+  // content and machine to hardcode a cross-codec conversion.
+  function currentExportSizeCalibration(format = exportFormat) {
     const templates = exportSizeCalibration.templates ?? {}
     const key = loadedTemplateFilename ?? ''
-    return templates[key] ?? templates[''] ?? null
+    const fmt = calibrationFormat(format)
+    return templates[key]?.[fmt] ?? templates['']?.[fmt] ?? null
+  }
+
+  // Real renders record wall throughput per codec. `lastRenderFps` is left to
+  // the benchmark (render-only, codec-agnostic) and legacy sessions — it
+  // approximates ProRes wall speed, where hardware encode overlaps rendering.
+  function recordRenderFps(format, fps) {
+    if (!(fps > 0)) return
+    renderFpsByFormat = {
+      ...renderFpsByFormat,
+      [calibrationFormat(format)]: fps,
+    }
+  }
+
+  // Best throughput guess for `format`: its own recorded renders (real
+  // exports or the quick test render). The render-only benchmark
+  // (`lastRenderFps`) approximates ProRes wall speed, where hardware encode
+  // overlaps rendering — it says nothing about qtrle's software encode, so an
+  // unmeasured qtrle returns null and the export dialog offers a test render
+  // instead of a made-up number.
+  function renderFpsFor(format) {
+    const fmt = calibrationFormat(format)
+    const own = renderFpsByFormat[fmt]
+    if (own > 0) return own
+    // ProRes and stitched both bottleneck on frame rendering, with hardware
+    // encode (ProRes / videotoolbox H.264) overlapping — so the render-only
+    // benchmark and any measured ProRes throughput approximate both. qtrle's
+    // software encode is unrelated, so it stays null and offers a test render.
+    if (fmt === 'prores' || fmt === 'stitched') {
+      if (lastRenderFps > 0) return lastRenderFps
+      if (renderFpsByFormat.prores > 0) return renderFpsByFormat.prores
+    }
+    return null
+  }
+
+  // Which codec the quick test render is currently measuring, or null. The
+  // export dialog shows progress on the matching option card.
+  let calibratingFormat = $state(null)
+
+  // Short real export — CALIBRATION_SECONDS of timeline, render + encode to a
+  // throwaway file — measuring wall speed and encoded size for `format` on
+  // this machine. Records both so the export dialog shows real numbers.
+  async function calibrateExportEstimate(format) {
+    if (renderingVideo || calibratingFormat) return
+    // Stitched can't be test-rendered — it would need the source footage too.
+    // Its numbers come from real exports instead.
+    if (format === 'stitched') return
+    if (!config?.scene || !gpxFilename || activityDuration <= 0) return
+    calibratingFormat = calibrationFormat(format)
+    try {
+      const r = await backend.nativeCalibrateExport(
+        config,
+        gpxFilename,
+        calibratingFormat,
+        CALIBRATION_SECONDS,
+        outputWidth,
+        outputHeight,
+      )
+      if (r.frames > 0 && r.elapsed_ms > 0)
+        recordRenderFps(format, (r.frames / r.elapsed_ms) * 1000)
+      const fps = config.scene.fps ?? 30
+      const bps = exportBitsPerPixelSecond(
+        r.bytes,
+        outputWidth,
+        outputHeight,
+        fps,
+        r.frames / fps,
+      )
+      if (bps) recordExportSizeEstimate(bps, format)
+    } catch (e) {
+      errorMessage = `Test render failed: ${e?.message ?? e}`
+    } finally {
+      calibratingFormat = null
+    }
   }
 
   function resolvePendingDiscard(ok) {
@@ -1267,6 +1384,12 @@ export function createAppState() {
     set outputHeight(v) {
       outputHeight = v
     },
+    get exportFormat() {
+      return exportFormat
+    },
+    set exportFormat(v) {
+      exportFormat = v
+    },
     get previewFps() {
       return previewFps
     },
@@ -1385,10 +1508,14 @@ export function createAppState() {
     set lastRenderFps(v) {
       lastRenderFps = v
     },
-    get exportSizeCalibration() {
-      return currentExportSizeCalibration()
-    },
+    exportSizeCalibrationFor: currentExportSizeCalibration,
     recordExportSizeEstimate,
+    recordRenderFps,
+    renderFpsFor,
+    get calibratingFormat() {
+      return calibratingFormat
+    },
+    calibrateExportEstimate,
     get benchmarking() {
       return benchmarking
     },

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -408,7 +408,11 @@ fn assets_search_dirs_vec() -> Vec<String> {
     dirs
 }
 
-fn resolve_output_path(template_json: &serde_json::Value, output_dir: Option<&str>) -> String {
+fn resolve_output_path(
+    template_json: &serde_json::Value,
+    output_dir: Option<&str>,
+    extension: &str,
+) -> String {
     let stem = template_json
         .pointer("/scene/overlay_filename")
         .and_then(|v| v.as_str())
@@ -420,7 +424,7 @@ fn resolve_output_path(template_json: &serde_json::Value, output_dir: Option<&st
         .unwrap_or_default()
         .as_secs();
     let (y, mo, d, h, mi) = unix_to_ymdhm(now);
-    let filename = format!("{stem}_{y}{mo:02}{d:02}_{h:02}{mi:02}.mov");
+    let filename = format!("{stem}_{y}{mo:02}{d:02}_{h:02}{mi:02}.{extension}");
 
     let dir = match output_dir {
         Some(d) if !d.is_empty() => {
@@ -1975,14 +1979,37 @@ async fn native_render(
     output_dir: Option<String>,
     target_width: Option<u32>,
     target_height: Option<u32>,
+    export_format: Option<String>,
+    stitch_video_path: Option<String>,
+    stitch_video_in: Option<f64>,
     state: tauri::State<'_, SharedRenderState>,
 ) -> Result<String, String> {
     log::info!(
-        "native_render: requested gpx={gpx_filename}, output_dir={:?}, target={:?}x{:?}",
+        "native_render: requested gpx={gpx_filename}, output_dir={:?}, target={:?}x{:?}, format={:?}, stitch={:?}@{:?}s",
         output_dir,
         target_width,
-        target_height
+        target_height,
+        export_format,
+        stitch_video_path,
+        stitch_video_in
     );
+    let export_format = export_format
+        .as_deref()
+        .map(render::scene::ExportFormat::from_str_lossy)
+        .unwrap_or_default();
+    let stitch = stitch_video_path.map(|video_path| render::scene::StitchOptions {
+        video_path,
+        video_in: stitch_video_in.unwrap_or(0.0),
+    });
+    if export_format == render::scene::ExportFormat::Stitched {
+        match &stitch {
+            None => return Err("Stitched export requires a source video".to_string()),
+            Some(s) if !std::path::Path::new(&s.video_path).exists() => {
+                return Err(format!("Source video not found: {}", s.video_path));
+            }
+            _ => {}
+        }
+    }
     let target = match (target_width, target_height) {
         (Some(w), Some(h)) => Some((w, h)),
         _ => None,
@@ -1996,7 +2023,12 @@ async fn native_render(
         template.scene.height,
         template.scene.fps
     );
-    let output_path = resolve_output_path(&config, output_dir.as_deref());
+    let output_ext = if export_format == render::scene::ExportFormat::Stitched {
+        "mp4"
+    } else {
+        "mov"
+    };
+    let output_path = resolve_output_path(&config, output_dir.as_deref(), output_ext);
     let fonts_dir = resolve_fonts_dir();
     let (gpx_path, _) = resolve_gpx_path(&gpx_filename)?;
     log::info!("native_render: resolved gpx={gpx_path}, output={output_path}");
@@ -2028,6 +2060,8 @@ async fn native_render(
                 &output_path,
                 &fonts_dir,
                 &assets_dirs,
+                export_format,
+                stitch.as_ref(),
                 &progress_clone,
             )
         }))
@@ -2358,6 +2392,87 @@ async fn native_benchmark(
     .map_err(|e| format!("Join error: {e}"))?
 }
 
+/// Runs a short real export — full pipeline including the FFmpeg encode — to a
+/// throwaway temp file and reports measured wall time and encoded size. The
+/// frontend uses this to calibrate render-time and file-size estimates for a
+/// codec on this machine, instead of deriving them from another codec's
+/// numbers via hardcoded ratios.
+#[tauri::command]
+async fn native_calibrate_export(
+    config: serde_json::Value,
+    gpx_filename: String,
+    export_format: String,
+    seconds: Option<f64>,
+    target_width: Option<u32>,
+    target_height: Option<u32>,
+) -> Result<String, String> {
+    let format = render::scene::ExportFormat::from_str_lossy(&export_format);
+    if format == render::scene::ExportFormat::Stitched {
+        // Estimating a stitched export would need the source footage too;
+        // its numbers come from real exports instead.
+        return Err("Calibration is not supported for stitched export".to_string());
+    }
+    let target = match (target_width, target_height) {
+        (Some(w), Some(h)) => Some((w, h)),
+        _ => None,
+    };
+    let mut template = render::template::Template::from_value_scaled(config, target)
+        .map_err(|e| format!("Template parse error: {e}"))?;
+    // Clip the scene window to a short slice at the overlay start: same
+    // template, resolution, and crop as the real export — just brief.
+    let seconds = seconds.unwrap_or(3.0).clamp(1.0, 10.0);
+    let start = template.scene.start.unwrap_or(0.0);
+    let end = template
+        .scene
+        .end
+        .map_or(start + seconds, |e| e.min(start + seconds));
+    template.scene.start = Some(start);
+    template.scene.end = Some(end.max(start + 1.0));
+
+    let fonts_dir = resolve_fonts_dir();
+    let (gpx_path, _) = resolve_gpx_path(&gpx_filename)?;
+    let assets_dirs_owned = assets_search_dirs_vec();
+
+    tokio::task::spawn_blocking(move || {
+        let output_path = std::env::temp_dir()
+            .join(format!("cyclemetry-calibrate-{export_format}.mov"))
+            .to_string_lossy()
+            .into_owned();
+        let progress = render::scene::RenderProgress::new();
+        let assets_dirs: Vec<&str> = assets_dirs_owned.iter().map(String::as_str).collect();
+        let t0 = std::time::Instant::now();
+        let result = render::scene::render_video(
+            &gpx_path,
+            &template,
+            &output_path,
+            &fonts_dir,
+            &assets_dirs,
+            format,
+            None,
+            &progress,
+        );
+        let elapsed_ms = t0.elapsed().as_millis() as u64;
+        let bytes = std::fs::metadata(&output_path)
+            .map(|m| m.len())
+            .unwrap_or(0);
+        let _ = std::fs::remove_file(&output_path);
+        let _ = std::fs::remove_file(format!("{output_path}.placement.txt"));
+        result?;
+        let (frames, _) = progress.snapshot();
+        if frames == 0 || bytes == 0 {
+            return Err("Test render produced no output".to_string());
+        }
+        Ok(serde_json::json!({
+            "frames": frames,
+            "elapsed_ms": elapsed_ms,
+            "bytes": bytes,
+        })
+        .to_string())
+    })
+    .await
+    .map_err(|e| format!("Join error: {e}"))?
+}
+
 // ─── Recent GPX state ─────────────────────────────────────────────────────────
 
 type SharedRecentGpx = Arc<Mutex<Vec<String>>>;
@@ -2420,6 +2535,7 @@ pub fn run() {
             native_cancel,
             native_demo,
             native_benchmark,
+            native_calibrate_export,
             backend_list_templates,
             backend_get_template,
             backend_save_template,

--- a/src-tauri/src/render/scene.rs
+++ b/src-tauri/src/render/scene.rs
@@ -19,6 +19,53 @@ use crate::render::activity::Activity;
 use crate::render::frame::{SceneCache, render_frame};
 use crate::render::template::Template;
 
+/// Export codec/output, chosen by the user at render time.
+///
+/// ProRes 4444 is the default: visually lossless, hardware-accelerated on
+/// macOS, and native in professional NLEs. QuickTime Animation (qtrle) is
+/// lossless RGBA and decodes in consumer editors that lack ProRes support
+/// (e.g. Adobe Premiere Elements on Windows), at ~1.1–1.9× the file size.
+/// Both keep transparency and live in a `.mov` container.
+///
+/// Stitched is different in kind: it composites the overlay onto the user's
+/// ride footage and emits a finished H.264 `.mp4` — no editor needed. It
+/// requires a [`StitchOptions`] describing the source video.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ExportFormat {
+    #[default]
+    ProRes4444,
+    QtRle,
+    Stitched,
+}
+
+impl ExportFormat {
+    pub fn from_str_lossy(s: &str) -> Self {
+        match s {
+            "qtrle" => ExportFormat::QtRle,
+            "prores" => ExportFormat::ProRes4444,
+            "stitched" => ExportFormat::Stitched,
+            other => {
+                log::warn!("unknown export format '{other}', defaulting to ProRes 4444");
+                ExportFormat::ProRes4444
+            }
+        }
+    }
+}
+
+/// Source footage for a stitched export.
+///
+/// The frontend owns timeline alignment (camera wall clock + user offset), so
+/// it hands over plain video-relative timing: `video_in` is where, in seconds
+/// from the start of the footage file, the overlay's first rendered frame
+/// lands. The frontend also clamps the scene window to the footage extent
+/// before rendering, so the overlay and the trimmed footage cover the same
+/// wall-clock span.
+#[derive(Debug, Clone)]
+pub struct StitchOptions {
+    pub video_path: String,
+    pub video_in: f64,
+}
+
 pub struct RenderProgress {
     pub frames_rendered: Arc<AtomicU64>,
     pub total_frames: Arc<AtomicU64>,
@@ -53,11 +100,20 @@ pub fn render_video(
     output_path: &str,
     fonts_dir: &str,
     assets_dirs: &[&str],
+    export_format: ExportFormat,
+    stitch: Option<&StitchOptions>,
     progress: &RenderProgress,
 ) -> Result<(), String> {
     log::info!(
         "render_video: start gpx={gpx_path}, output={output_path}, assets_dirs={assets_dirs:?}"
     );
+    let stitch = match (export_format, stitch) {
+        (ExportFormat::Stitched, None) => {
+            return Err("Stitched export requires a source video".to_string());
+        }
+        (ExportFormat::Stitched, some) => some,
+        _ => None,
+    };
 
     // --- Load and prepare activity data ---
     log::info!("render_video: loading activity");
@@ -132,16 +188,28 @@ pub fn render_video(
 
     // --- Spawn FFmpeg ---
     let ffmpeg_bin = resolve_ffmpeg();
-    let encoder = select_ffmpeg_encoder(&ffmpeg_bin)?;
+    let encoder = select_ffmpeg_encoder(&ffmpeg_bin, export_format)?;
     log::info!(
         "render_video: spawning FFmpeg from {ffmpeg_bin} with {} ({})",
         encoder.codec,
         encoder.mode
     );
     let mut cmd = ffmpeg_command(&ffmpeg_bin);
+    cmd.args(["-loglevel", "warning"]);
+    if let Some(st) = stitch {
+        // Input 0: source footage, trimmed to the export window. `-ss` before
+        // `-i` seeks frame-accurately when re-encoding.
+        let duration = total_frames as f64 / template.scene.fps as f64;
+        cmd.args([
+            "-ss",
+            &format!("{:.3}", st.video_in.max(0.0)),
+            "-t",
+            &format!("{duration:.3}"),
+            "-i",
+            &st.video_path,
+        ]);
+    }
     cmd.args([
-        "-loglevel",
-        "warning",
         "-f",
         "rawvideo",
         // Skia renders BGRA8888 natively; feeding bgra means FFmpeg does
@@ -154,16 +222,47 @@ pub fn render_video(
         &template.scene.fps.to_string(),
         "-i",
         "-",
-        "-c:v",
-        &encoder.codec,
-        "-profile:v",
-        "4444",
-        "-y",
-        output_path,
-    ])
-    .stdin(Stdio::piped())
-    .stdout(Stdio::null())
-    .stderr(Stdio::piped());
+    ]);
+    if stitch.is_some() {
+        // Composite: footage scaled (letterboxed if aspect differs) to the
+        // overlay canvas, cropped overlay placed at its canvas offset on top.
+        // The overlay pipe runs at scene fps; `overlay` repeats its last frame
+        // between updates, so higher-fps footage keeps its native cadence.
+        let (cw, ch) = ((full_w + 1) & !1, (full_h + 1) & !1);
+        let (ox, oy) = crop.as_ref().map_or((0, 0), |c| (c.x, c.y));
+        let filter = format!(
+            "[0:v]scale={cw}:{ch}:force_original_aspect_ratio=decrease,\
+             pad={cw}:{ch}:-1:-1[bg];[bg][1:v]overlay={ox}:{oy}[out]"
+        );
+        cmd.args([
+            "-filter_complex",
+            &filter,
+            "-map",
+            "[out]",
+            "-map",
+            "0:a?",
+            "-c:a",
+            "aac",
+            "-shortest",
+        ]);
+    }
+    cmd.args(["-c:v", &encoder.codec])
+        .args(encoder_output_args(&encoder.codec));
+    if stitch.is_some() {
+        cmd.args(stitched_quality_args(
+            &encoder.codec,
+            full_w,
+            full_h,
+            template.scene.fps,
+        ));
+        // faststart moves the moov atom up front so the file streams/scrubs
+        // immediately when shared.
+        cmd.args(["-movflags", "+faststart"]);
+    }
+    cmd.args(["-y", output_path])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
     let mut ffmpeg = cmd
         .spawn()
         .map_err(|e| format!("Failed to spawn FFmpeg ({ffmpeg_bin}): {e}"))?;
@@ -430,8 +529,11 @@ pub fn render_video(
 
     // Cropped output is smaller than the footage canvas — record exactly where
     // it must be positioned so it isn't guessed-at in the editor later.
+    // Stitched exports bake the placement in, so no sidecar is needed.
     if let Some(c) = crop {
-        write_placement_sidecar(output_path, c, full_w, full_h);
+        if stitch.is_none() {
+            write_placement_sidecar(output_path, c, full_w, full_h);
+        }
     }
 
     Ok(())
@@ -611,13 +713,54 @@ pub(crate) fn ffmpeg_command(ffmpeg_bin: &str) -> Command {
     }
 }
 
-/// Select the best alpha-preserving ProRes encoder this FFmpeg can actually run.
+/// Per-codec output arguments appended after `-c:v <codec>`.
 ///
-/// Cyclemetry exports transparent overlays as ProRes 4444. Windows/Linux GPU
-/// encoders generally accelerate H.264/HEVC/AV1, not ProRes 4444 with alpha, so
-/// `prores_ks` remains the portable fallback unless FFmpeg gains another working
-/// ProRes hardware encoder on those platforms.
-fn select_ffmpeg_encoder(ffmpeg_bin: &str) -> Result<FfmpegEncoder, String> {
+/// ProRes needs `-profile:v 4444` to select the alpha-carrying profile.
+/// qtrle needs an explicit `-pix_fmt argb` — it's the only qtrle pixel format
+/// with alpha, and relying on FFmpeg's automatic selection risks a build
+/// silently picking `rgb24` and dropping the alpha channel.
+/// H.264 (stitched export) gets `yuv420p` — the only universally-decodable
+/// H.264 pixel format (QuickTime and browsers reject 4:2:2 and up).
+fn encoder_output_args(codec: &str) -> &'static [&'static str] {
+    if codec.starts_with("prores") {
+        &["-profile:v", "4444"]
+    } else if codec == "qtrle" {
+        &["-pix_fmt", "argb"]
+    } else if codec.starts_with("h264") || codec == "libx264" {
+        &["-pix_fmt", "yuv420p"]
+    } else {
+        &[]
+    }
+}
+
+/// Quality arguments for the stitched H.264 encode.
+///
+/// `h264_videotoolbox` is bitrate-driven and its default is far too low for
+/// sports footage — target ~0.12 bits per pixel per frame (≈30 Mbps for
+/// 4K30), in the ballpark of action-camera sources. libx264 does better
+/// quality-per-bit with CRF, so it gets that instead.
+fn stitched_quality_args(codec: &str, w: u32, h: u32, fps: u32) -> Vec<String> {
+    if codec == "libx264" {
+        return ["-crf", "18", "-preset", "veryfast"]
+            .map(String::from)
+            .to_vec();
+    }
+    let bits_per_sec = (w as f64 * h as f64 * fps as f64 * 0.12) as u64;
+    vec!["-b:v".to_string(), bits_per_sec.to_string()]
+}
+
+/// Select the encoder for the requested export format that this FFmpeg can
+/// actually run.
+///
+/// ProRes 4444: Windows/Linux GPU encoders generally accelerate
+/// H.264/HEVC/AV1, not ProRes 4444 with alpha, so `prores_ks` remains the
+/// portable fallback unless FFmpeg gains another working ProRes hardware
+/// encoder on those platforms.
+///
+/// QuickTime Animation (`qtrle`): software-only, built into every FFmpeg.
+///
+/// Stitched (H.264): `h264_videotoolbox` on macOS, `libx264` elsewhere.
+fn select_ffmpeg_encoder(ffmpeg_bin: &str, format: ExportFormat) -> Result<FfmpegEncoder, String> {
     if let Ok(codec) = std::env::var("CYCLEMETRY_FFMPEG_CODEC") {
         let codec = codec.trim();
         if !codec.is_empty() {
@@ -631,6 +774,15 @@ fn select_ffmpeg_encoder(ffmpeg_bin: &str) -> Result<FfmpegEncoder, String> {
         }
     }
 
+    if format == ExportFormat::QtRle {
+        preflight_ffmpeg_encoder(ffmpeg_bin, "qtrle")
+            .map_err(|e| format!("FFmpeg qtrle preflight failed: {e}"))?;
+        return Ok(FfmpegEncoder {
+            codec: "qtrle".to_string(),
+            mode: "software",
+        });
+    }
+
     let encoders = match available_ffmpeg_encoders(ffmpeg_bin) {
         Ok(encoders) => Some(encoders),
         Err(e) => {
@@ -638,6 +790,40 @@ fn select_ffmpeg_encoder(ffmpeg_bin: &str) -> Result<FfmpegEncoder, String> {
             None
         }
     };
+
+    if format == ExportFormat::Stitched {
+        let should_try_videotoolbox = encoders
+            .as_ref()
+            .map(|e| e.contains("h264_videotoolbox"))
+            .unwrap_or_else(|| cfg!(target_os = "macos"));
+        if should_try_videotoolbox {
+            match preflight_ffmpeg_encoder(ffmpeg_bin, "h264_videotoolbox") {
+                Ok(()) => {
+                    return Ok(FfmpegEncoder {
+                        codec: "h264_videotoolbox".to_string(),
+                        mode: "hardware",
+                    });
+                }
+                Err(e) => {
+                    log::warn!(
+                        "render_video: h264_videotoolbox is present but failed preflight; \
+                         falling back to libx264: {e}"
+                    );
+                }
+            }
+        }
+        if encoder_is_listed(encoders.as_ref(), "libx264") {
+            preflight_ffmpeg_encoder(ffmpeg_bin, "libx264")
+                .map_err(|e| format!("FFmpeg libx264 preflight failed: {e}"))?;
+            return Ok(FfmpegEncoder {
+                codec: "libx264".to_string(),
+                mode: "software",
+            });
+        }
+        return Err(
+            "FFmpeg does not provide a working H.264 encoder for stitched export.".to_string(),
+        );
+    }
 
     let should_try_videotoolbox = encoders
         .as_ref()
@@ -731,12 +917,9 @@ fn preflight_ffmpeg_encoder(ffmpeg_bin: &str, codec: &str) -> Result<(), String>
         "1",
         "-c:v",
         codec,
-        "-profile:v",
-        "4444",
-        "-f",
-        "null",
-        "-",
     ])
+    .args(encoder_output_args(codec))
+    .args(["-f", "null", "-"])
     .stdin(Stdio::piped())
     .stdout(Stdio::null())
     .stderr(Stdio::piped());
@@ -805,5 +988,57 @@ mod tests {
         assert!(encoders.contains("h264_videotoolbox"));
         assert!(encoders.contains("prores_ks"));
         assert!(encoders.contains("prores_videotoolbox"));
+    }
+
+    #[test]
+    fn parses_export_format() {
+        assert_eq!(
+            ExportFormat::from_str_lossy("prores"),
+            ExportFormat::ProRes4444
+        );
+        assert_eq!(ExportFormat::from_str_lossy("qtrle"), ExportFormat::QtRle);
+        assert_eq!(
+            ExportFormat::from_str_lossy("stitched"),
+            ExportFormat::Stitched
+        );
+        // Unknown values fall back to the default rather than failing a render.
+        assert_eq!(
+            ExportFormat::from_str_lossy("bogus"),
+            ExportFormat::ProRes4444
+        );
+    }
+
+    #[test]
+    fn encoder_output_args_preserve_alpha() {
+        // ProRes needs the 4444 profile — the only alpha-carrying profile.
+        assert_eq!(
+            encoder_output_args("prores_videotoolbox"),
+            ["-profile:v", "4444"]
+        );
+        assert_eq!(encoder_output_args("prores_ks"), ["-profile:v", "4444"]);
+        // qtrle needs argb forced — auto-selection could pick rgb24 (no alpha).
+        assert_eq!(encoder_output_args("qtrle"), ["-pix_fmt", "argb"]);
+        // Stitched H.264 must be yuv420p or QuickTime/browsers won't play it.
+        assert_eq!(
+            encoder_output_args("h264_videotoolbox"),
+            ["-pix_fmt", "yuv420p"]
+        );
+        assert_eq!(encoder_output_args("libx264"), ["-pix_fmt", "yuv420p"]);
+    }
+
+    #[test]
+    fn stitched_quality_args_by_codec() {
+        // videotoolbox needs an explicit bitrate (its default is too low);
+        // 4K30 at 0.12 bits/pixel/frame ≈ 30 Mbps.
+        assert_eq!(
+            stitched_quality_args("h264_videotoolbox", 3840, 2160, 30),
+            ["-b:v", "29859840"]
+        );
+        // libx264 is CRF-driven instead.
+        assert!(
+            stitched_quality_args("libx264", 3840, 2160, 30)
+                .join(" ")
+                .contains("-crf")
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Render button now opens a format picker (ProRes 4444, Animation/RLE, or stitched MP4 with the overlay burned onto the source video) instead of always producing a ProRes overlay.
- Each format card shows a same-machine time/size estimate, calibrated in the background shortly after an activity or template loads.
- Render progress collapses to a header status chip so a long render doesn't block the UI; the full dialog reopens on demand.

## Test plan
- [ ] Load an activity + template, confirm export dialog shows estimates for ProRes/Animation, and stitched once a video is loaded
- [ ] Render each format and confirm output plays correctly (transparency for ProRes/Animation, burned-in overlay for stitched)
- [ ] Minimize render dialog to header chip mid-render, confirm render continues and chip reflects progress
- [ ] Verify Escape minimizes rather than cancels an in-progress render

🤖 Generated with [Claude Code](https://claude.com/claude-code)