### PR TITLE
Remove redundant "Properties" header from right panel

### DIFF
--- a/app/src/components/layout/RightPanel.svelte
+++ b/app/src/components/layout/RightPanel.svelte
@@ -1,10 +1,9 @@
 <script>
   import { getContext } from 'svelte'
-  import { Sparkles } from 'lucide-svelte'
   import ElementProperties from '../panels/ElementProperties.svelte'
   import AiChatPanel from '../panels/AiChatPanel.svelte'
 
-  let { aiChatOpen = false, onreopenAiChat, aiAssistantEnabled = true } = $props()
+  let { aiChatOpen = false, aiAssistantEnabled = true } = $props()
 
   const app = getContext('app')
 </script>
@@ -20,22 +19,11 @@
     </div>
   {/if}
 
-  <!-- Properties panel — shown when AI chat is closed and something is selected -->
+  <!-- Properties panel — shown when AI chat is closed and something is selected.
+       The panel leads with ElementProperties' own element-type header, so no
+       separate "Properties" chrome row is needed. -->
   {#if !aiChatOpen}
     {#if app.selectedElementId || app.selectedGroupId}
-      <div class="px-4 py-3 border-b border-zinc-800 flex items-center justify-between shrink-0">
-        <p class="text-[10px] font-semibold uppercase tracking-wider text-zinc-500">Properties</p>
-        {#if aiAssistantEnabled}
-          <button
-            onclick={onreopenAiChat}
-            title="Open AI assistant"
-            class="cursor-pointer h-5 w-5 flex items-center justify-center rounded text-zinc-600
-                 hover:text-[#dc143c] hover:bg-zinc-800 transition-colors"
-          >
-            <Sparkles size={11} />
-          </button>
-        {/if}
-      </div>
       <ElementProperties />
     {/if}
   {/if}


### PR DESCRIPTION
## What

Removes the generic **"Properties"** chrome row at the top of the right panel.

## Why

The properties panel already leads with `ElementProperties`' own element-type header (e.g. "Fill Meter", "Text Label"), so the "Properties" label above it was redundant.

That same row also hosted the AI-assistant reopen button (Sparkles). With the AI feature still behind the `AI_ASSISTANT_ENABLED` flag and being built out, we're hiding that button for now — so dropping the whole row is the clean move.

## Changes

- Delete the header `<div>` row from `RightPanel.svelte`
- Remove the now-unused `Sparkles` import and `onreopenAiChat` prop (`aiAssistantEnabled` is kept — it still gates the chat panel)

One file, +4/−16. Frontend `vite build` and ESLint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)