### PR TITLE
Color elevation chart by grade

### DIFF
--- a/app/src/components/panels/ElementProperties.svelte
+++ b/app/src/components/panels/ElementProperties.svelte
@@ -14,7 +14,7 @@
   import ColorInput from '../ui/ColorInput.svelte'
   import AssetPicker from '../overlays/AssetPicker.svelte'
   import * as backend from '../../api/backend.js'
-  import { elementTypeName } from '../../lib/elementTypes.js'
+  import { defaultColorBands, elementTypeName } from '../../lib/elementTypes.js'
   import { metricRangeIssues, metricValueIssue } from '../../lib/metricLimits.js'
   import { normalizeElementField, normalizeTemplateIntegerField } from '../../lib/templateSchema.js'
 
@@ -135,6 +135,28 @@
     { value: 'right', label: 'Fill rightward' },
     { value: 'left', label: 'Fill leftward' },
   ]
+  // Metrics that can drive plot band colors (must have per-frame plot data).
+  const ALL_COLOR_BY_METRICS = ['gradient', 'speed', 'power', 'heartrate', 'cadence', 'temperature', 'elevation']
+  const COLOR_BY_METRICS = $derived(filterMetrics(ALL_COLOR_BY_METRICS))
+  const COLOR_BY_MODES = [
+    { value: 'fill', label: 'Fill under curve' },
+    { value: 'line', label: 'Line' },
+    { value: 'both', label: 'Fill + line' },
+  ]
+  // Unit the band thresholds are read in ('' = the metric's default display
+  // unit, matching units::resolve on the Rust side).
+  const COLOR_BY_UNITS = {
+    speed: [{ value: '', label: 'km/h' }, { value: 'mph', label: 'mph' }],
+    temperature: [{ value: '', label: '°C' }, { value: 'f', label: '°F' }],
+    elevation: [{ value: '', label: 'm' }, { value: 'ft', label: 'ft' }],
+  }
+  const COLOR_BY_UNIT_HINTS = { gradient: '%', power: 'W', heartrate: 'bpm', cadence: 'rpm' }
+  function colorByUnitHint(cb) {
+    const metric = cb.value ?? 'gradient'
+    const units = COLOR_BY_UNITS[metric]
+    if (units) return (units.find((u) => u.value === (cb.unit ?? '')) ?? units[0]).label
+    return COLOR_BY_UNIT_HINTS[metric] ?? ''
+  }
   const COURSE_MARKER_STYLES = [
     { value: 'checkered', label: 'Checkered finish' },
     { value: 'circle', label: 'Colored circle' },
@@ -706,6 +728,58 @@ Looks unrealistic for ${item.value} (expected ${issue.expected}). Enter a manual
     } else {
       app.updateElement(s.id, { color: raw })
     }
+  }
+
+  // ── Plot color-by (banded coloring by a second metric) ────────────────────
+  function colorBy() {
+    return selected()?.item.color_by ?? null
+  }
+  function setColorBy(next) {
+    const s = selected()
+    if (!s) return
+    app.updateElement(s.id, { color_by: next })
+  }
+  function toggleColorBy(on) {
+    if (!on) return setColorBy(undefined)
+    const s = selected()
+    if (!s) return
+    // Banded fills read best solid; lift a translucent fill to full opacity
+    // in the same (single-undo) update.
+    const patch = { color_by: { value: 'gradient', bands: defaultColorBands('gradient') } }
+    const fillOpacity = s.item.fill?.opacity
+    if (s.item.value !== 'course' && typeof fillOpacity === 'number' && fillOpacity < 1) {
+      patch.fill = { ...s.item.fill, opacity: 1 }
+    }
+    app.updateElement(s.id, patch)
+  }
+  // Changing the driving metric resets bands — thresholds are metric-specific.
+  function setColorByMetric(metric) {
+    setColorBy({ ...colorBy(), value: metric, unit: undefined, bands: defaultColorBands(metric) })
+  }
+  function setColorByField(field, value) {
+    setColorBy({ ...colorBy(), [field]: value })
+  }
+  function colorByBands() {
+    return colorBy()?.bands ?? []
+  }
+  function updateColorBand(i, patch) {
+    const bands = colorByBands().map((b, idx) => (idx === i ? { ...b, ...patch } : b))
+    setColorBy({ ...colorBy(), bands })
+  }
+  function removeColorBand(i) {
+    setColorBy({ ...colorBy(), bands: colorByBands().filter((_, idx) => idx !== i) })
+  }
+  function addColorBand() {
+    const bands = [...colorByBands()]
+    const maxes = bands.map((b) => b.max).filter((m) => typeof m === 'number').sort((a, b) => a - b)
+    const top = maxes.at(-1)
+    const step = maxes.length >= 2 ? maxes.at(-1) - maxes.at(-2) : 5
+    const next = { max: top != null ? top + step : 0, color: bands.at(-1)?.color ?? '#ffffff' }
+    // Keep the catch-all (no max) band last.
+    const catchAll = bands.length && bands.at(-1).max == null ? bands.pop() : null
+    bands.push(next)
+    if (catchAll) bands.push(catchAll)
+    setColorBy({ ...colorBy(), bands })
   }
 
   // Meter gradient stops (ordered min→max). Absent = solid `color`.
@@ -1292,6 +1366,65 @@ Looks unrealistic for ${item.value} (expected ${issue.expected}). Enter a manual
           <span class="text-xs text-zinc-500">Opacity (0–1)</span>
           <OpacityControl value={item.opacity ?? 1} oninput={(e) => update('opacity', e.target.value)} />
         </label>
+        {/if}
+      </section>
+
+      <!-- Color by: band-color segments by a second metric (TdF-style profiles) -->
+      {@const cb = item.color_by}
+      <section class="mb-4 space-y-2">
+        <p class="text-[10px] uppercase tracking-wider text-zinc-600">Color by Metric</p>
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" checked={cb != null}
+            onchange={(e) => toggleColorBy(e.target.checked)}
+            class="accent-primary" />
+          <span class="text-xs text-zinc-400">Color segments by a second metric</span>
+        </label>
+        {#if cb != null}
+          <label class="space-y-1 block">
+            <span class="text-xs text-zinc-500">Metric</span>
+            <Select
+              value={cb.value ?? 'gradient'}
+              options={COLOR_BY_METRICS.map((m) => ({ value: m, label: metricLabel(m) }))}
+              onchange={setColorByMetric}
+            />
+          </label>
+          {#if item.value === 'course'}
+            <p class="text-[10px] text-zinc-600 italic">Colors the route line.</p>
+          {:else}
+            <label class="space-y-1 block">
+              <span class="text-xs text-zinc-500">Apply to</span>
+              <Select value={cb.mode ?? 'fill'} options={COLOR_BY_MODES}
+                onchange={(v) => setColorByField('mode', v)} />
+            </label>
+          {/if}
+          {#if COLOR_BY_UNITS[cb.value ?? 'gradient']}
+            <label class="space-y-1 block">
+              <span class="text-xs text-zinc-500">Threshold unit</span>
+              <Select value={cb.unit ?? ''} options={COLOR_BY_UNITS[cb.value ?? 'gradient']}
+                onchange={(v) => setColorByField('unit', v || undefined)} />
+            </label>
+          {/if}
+          <div class="space-y-1">
+            <div class="flex items-center justify-between">
+              <span class="text-xs text-zinc-500">Bands — up to ({colorByUnitHint(cb)})</span>
+              <button type="button" class="cursor-pointer text-xs text-primary hover:underline"
+                onclick={addColorBand}>+ band</button>
+            </div>
+            {#each colorByBands() as band, i (i)}
+              <div class="flex gap-2 items-center">
+                {#if band.max != null}
+                  <Input type="number" value={band.max} step={1} class="w-20 shrink-0"
+                    oninput={(e) => updateColorBand(i, { max: e.target.value === '' ? 0 : Number(e.target.value) })} />
+                {:else}
+                  <span class="w-20 shrink-0 text-center text-xs text-zinc-500">above</span>
+                {/if}
+                <ColorInput value={band.color ?? '#ffffff'} vars={sceneVars}
+                  onchange={(v) => updateColorBand(i, { color: v })} class="flex-1 min-w-0" />
+                <button type="button" class="cursor-pointer text-xs text-zinc-500 hover:text-red-400 px-1 shrink-0"
+                  onclick={() => removeColorBand(i)} aria-label="Remove band">✕</button>
+              </div>
+            {/each}
+          </div>
         {/if}
       </section>
 

--- a/app/src/lib/elementTypes.js
+++ b/app/src/lib/elementTypes.js
@@ -142,6 +142,20 @@
  */
 
 /**
+ * @typedef {Object} ColorBand
+ * @property {number} [max] Upper bound (exclusive) in display units; absent = catch-all top band.
+ * @property {string} color
+ */
+
+/**
+ * @typedef {Object} ColorByConfig Band-colors plot segments by a second metric (TdF-style climb profiles).
+ * @property {string} [value] Metric driving the color (default 'gradient').
+ * @property {string} [unit] Unit token for band thresholds (e.g. 'mph'); absent = metric display unit.
+ * @property {'fill'|'line'|'both'} [mode] What gets colored (default 'fill'; course plots always color the line).
+ * @property {ColorBand[]} [bands] Ordered bands; absent falls back to built-in gradient bands.
+ */
+
+/**
  * @typedef {Object} PlotElement
  * @property {'plot'} type
  * @property {string} id
@@ -155,12 +169,53 @@
  * @property {number} [opacity]
  * @property {LineConfig} [line]
  * @property {FillConfig} [fill]
+ * @property {ColorByConfig} [color_by]
  * @property {number} [margin]
  * @property {PointConfig} [point]
  * @property {CourseMarkerConfig[]} [markers]
  * @property {PointLabelConfig} [point_label]
  * @property {number} [rotation]
  */
+
+// Mirrors DEFAULT_GRADIENT_BANDS in src-tauri/src/render/template.rs: descent,
+// then TdF-style climb categories. Thresholds in percent grade.
+export const GRADIENT_COLOR_BANDS = [
+  { max: 0, color: '#3b82f6' },
+  { max: 4, color: '#22c55e' },
+  { max: 7, color: '#eab308' },
+  { max: 10, color: '#f97316' },
+  { max: 14, color: '#dc2626' },
+  { color: '#7f1d1d' },
+]
+
+// Cold→hot ramp used to seed bands for non-gradient color-by metrics.
+const COLOR_BY_RAMP = ['#3b82f6', '#22c55e', '#eab308', '#f97316', '#dc2626']
+
+// Starter thresholds per metric, in the unit band values are authored in
+// (speed km/h, power W, heartrate bpm, cadence rpm, temperature °C, elevation m).
+const COLOR_BY_THRESHOLDS = {
+  speed: [10, 20, 30, 40],
+  power: [150, 220, 290, 360],
+  heartrate: [120, 140, 160, 180],
+  cadence: [60, 75, 90, 105],
+  temperature: [5, 15, 25, 32],
+  elevation: [250, 750, 1500, 2500],
+}
+
+/**
+ * Fresh default bands for a color-by metric — a starting point the user
+ * customizes. Returns new objects each call so edits never share state.
+ * @param {string} metric
+ * @returns {ColorBand[]}
+ */
+export function defaultColorBands(metric) {
+  if (metric === 'gradient' || !(metric in COLOR_BY_THRESHOLDS)) {
+    return GRADIENT_COLOR_BANDS.map((b) => ({ ...b }))
+  }
+  const bands = COLOR_BY_THRESHOLDS[metric].map((max, i) => ({ max, color: COLOR_BY_RAMP[i] }))
+  bands.push({ color: COLOR_BY_RAMP[COLOR_BY_RAMP.length - 1] })
+  return bands
+}
 
 /**
  * @typedef {Object} MeterElement

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1240,8 +1240,8 @@ fn backend_upload(file_data: Vec<u8>, filename: String) -> Result<String, String
 /// needs it to map activity time onto the video's `creation_time` axis.
 fn gpx_metadata_response(filename: &str, path: &str) -> Result<String, String> {
     use chrono::{TimeZone, Utc};
-    let activity = render::activity::Activity::from_file(path)
-        .map_err(|e| format!("Could not read activity file: {e}"))?;
+    let activity =
+        load_activity_cached(path).map_err(|e| format!("Could not read activity file: {e}"))?;
     if !activity.has_wall_clock_time_axis() {
         return Err(
             "This activity file does not include usable timestamps. Cyclemetry needs activity timestamps to align the overlay timeline.".to_string(),
@@ -1511,9 +1511,9 @@ async fn backend_activity_distance_info(
     let synthetic = gpx_path == "<synthetic>";
     let activity = if synthetic {
         let duration = (scene_end.ceil() as usize).max(60);
-        render::activity::Activity::synthetic(duration)
+        Arc::new(render::activity::Activity::synthetic(duration))
     } else {
-        render::activity::Activity::from_file(&gpx_path)?
+        load_activity_cached(&gpx_path)?
     };
     let total_m = activity.total_activity_distance;
     let scene = render::template::SceneConfig {
@@ -1551,7 +1551,7 @@ async fn backend_activity_distance_info(
 #[tauri::command]
 async fn backend_activity_start_time_ms(gpx_filename: String) -> Option<i64> {
     let path = resolve_gpx_path(&gpx_filename).ok()?.0;
-    render::activity::Activity::from_file(&path)
+    load_activity_cached(&path)
         .ok()
         .and_then(|a| a.start_time_ms)
 }
@@ -1573,9 +1573,9 @@ async fn backend_activity_metric_range(
     let synthetic = gpx_path == "<synthetic>";
     let activity = if synthetic {
         let duration = (scene_end.ceil() as usize).max(60);
-        render::activity::Activity::synthetic(duration)
+        Arc::new(render::activity::Activity::synthetic(duration))
     } else {
-        render::activity::Activity::from_file(&gpx_path)?
+        load_activity_cached(&gpx_path)?
     };
     let scene = render::template::SceneConfig {
         width: 1,
@@ -1979,6 +1979,56 @@ struct DemoCache {
 }
 type SharedDemoCache = Arc<Mutex<Option<DemoCache>>>;
 
+/// Cheap identity stamp for a ride file: (byte length, mtime seconds).
+/// `None` for the synthetic pseudo-path or when the file can't be statted.
+fn gpx_file_stamp(path: &str) -> Option<(u64, i64)> {
+    let meta = std::fs::metadata(path).ok()?;
+    let mtime = meta
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs() as i64;
+    Some((meta.len(), mtime))
+}
+
+/// Process-wide cache of the most recently parsed ride file.
+///
+/// A single config change fans out into many commands that each need the
+/// parsed activity — the preview rebuild, one metric-range call per meter
+/// metric, the distance-slider info. Parsing a large FIT ride costs seconds of
+/// CPU, so without this cache a timeline-trim change ran ~a dozen full parses
+/// in parallel. Callers still window/resample per their own scene params.
+struct ParsedActivity {
+    path: String,
+    stamp: Option<(u64, i64)>,
+    activity: Arc<render::activity::Activity>,
+}
+static PARSED_ACTIVITY: Mutex<Option<ParsedActivity>> = Mutex::new(None);
+
+/// Parse `path` or return the cached parse if the file is unchanged.
+/// The parse deliberately happens while holding the lock: concurrent misses
+/// for the same file wait for one parse instead of racing N identical ones.
+fn load_activity_cached(path: &str) -> Result<Arc<render::activity::Activity>, String> {
+    let stamp = gpx_file_stamp(path);
+    let mut guard = PARSED_ACTIVITY.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(entry) = guard.as_ref()
+        && entry.path == path
+        && entry.stamp == stamp
+        // An unreadable stamp can't prove the file is unchanged — re-parse.
+        && entry.stamp.is_some()
+    {
+        return Ok(entry.activity.clone());
+    }
+    let activity = Arc::new(render::activity::Activity::from_file(path)?);
+    *guard = Some(ParsedActivity {
+        path: path.to_string(),
+        stamp,
+        activity: activity.clone(),
+    });
+    Ok(activity)
+}
+
 fn quick_hash(s: &str) -> u64 {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
@@ -2253,11 +2303,12 @@ async fn native_demo(
             template.scene.rider_weight_kg = rider_weight_kg;
 
             let synthetic = gpx_path == "<synthetic>";
-            let activity = if synthetic {
-                render::activity::Activity::synthetic(60)
+            // Config-only rebuilds (timeline trim, element edits) reuse the
+            // parsed ride via the shared cache; only a changed file re-parses.
+            let source = if synthetic {
+                Arc::new(render::activity::Activity::synthetic(60))
             } else {
-                render::activity::Activity::from_file(&gpx_path)
-                    .map_err(|e| format!("GPX parse error: {e}"))?
+                load_activity_cached(&gpx_path).map_err(|e| format!("GPX parse error: {e}"))?
             };
             let mut preview_scene = template.scene.clone();
             preview_scene.fps = preview_fps;
@@ -2271,7 +2322,7 @@ async fn native_demo(
             preview_scene.target_duration = None;
             let mut preview_template = template.clone();
             preview_template.scene = preview_scene;
-            let activity = activity
+            let activity = source
                 .sample_for_scene(&preview_template.scene, synthetic)
                 .map_err(|e| format!("Activity timeline error: {e}"))?;
 
@@ -2408,10 +2459,9 @@ async fn native_benchmark(
     tokio::task::spawn_blocking(move || {
         let synthetic = gpx_path == "<synthetic>";
         let activity = if synthetic {
-            render::activity::Activity::synthetic(60)
+            Arc::new(render::activity::Activity::synthetic(60))
         } else {
-            render::activity::Activity::from_file(&gpx_path)
-                .map_err(|e| format!("GPX parse: {e}"))?
+            load_activity_cached(&gpx_path).map_err(|e| format!("GPX parse: {e}"))?
         };
         let activity = activity
             .sample_for_scene(&template.scene, synthetic)
@@ -3355,4 +3405,47 @@ pub fn run() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::load_activity_cached;
+
+    /// The parsed-activity cache must return the same parse for an unchanged
+    /// file and re-parse when the file's content (stamp) changes — this is
+    /// what collapses the N-parses-per-timeline-trim storm into one.
+    #[test]
+    fn parsed_activity_cache_hits_and_invalidates() {
+        let gpx = |elev: &str| {
+            format!(
+                r#"<gpx><trk><trkseg>
+                <trkpt lat="1" lon="2"><ele>{elev}</ele><time>2026-01-01T00:00:00Z</time></trkpt>
+                <trkpt lat="1" lon="2.001"><ele>{elev}</ele><time>2026-01-01T00:00:02Z</time></trkpt>
+                </trkseg></trk></gpx>"#
+            )
+        };
+        let dir = std::env::temp_dir().join("cyclemetry-cache-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("ride.gpx");
+        let path_str = path.to_string_lossy().to_string();
+
+        std::fs::write(&path, gpx("100")).unwrap();
+        let a = load_activity_cached(&path_str).unwrap();
+        let b = load_activity_cached(&path_str).unwrap();
+        assert!(
+            std::sync::Arc::ptr_eq(&a, &b),
+            "unchanged file should hit cache"
+        );
+
+        // Different content length → different stamp → fresh parse.
+        std::fs::write(&path, gpx("1234.5")).unwrap();
+        let c = load_activity_cached(&path_str).unwrap();
+        assert!(
+            !std::sync::Arc::ptr_eq(&a, &c),
+            "changed file should re-parse"
+        );
+        assert_ne!(a.elevation[0], c.elevation[0]);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/src-tauri/src/render/activity.rs
+++ b/src-tauri/src/render/activity.rs
@@ -489,7 +489,8 @@ impl Activity {
                                 pt.power = current_text.parse().ok();
                             }
                             "Speed" if in_extensions => {
-                                pt.speed = current_text.parse::<f64>().ok().filter(|v| v.is_finite());
+                                pt.speed =
+                                    current_text.parse::<f64>().ok().filter(|v| v.is_finite());
                             }
                             "front_gear" | "frontGear" | "front_gear_num" if in_extensions => {
                                 pt.front_gear = current_text.parse().ok();
@@ -664,7 +665,8 @@ impl Activity {
                                 pt.power = current_text.parse().ok();
                             }
                             "speed" => {
-                                pt.speed = current_text.parse::<f64>().ok().filter(|v| v.is_finite());
+                                pt.speed =
+                                    current_text.parse::<f64>().ok().filter(|v| v.is_finite());
                             }
                             "TrackPointExtension" => {
                                 in_tpx = false;
@@ -938,7 +940,7 @@ impl Activity {
     }
 
     pub fn sample_for_scene(
-        self,
+        &self,
         scene: &crate::render::template::SceneConfig,
         synthetic: bool,
     ) -> Result<Self, String> {
@@ -1804,7 +1806,10 @@ mod tests {
         };
 
         // bare <speed> (GPX 1.0, direct child of trkpt)
-        assert_eq!(speeds("<speed>5.0</speed>", "<speed>7.5</speed>"), vec![5.0, 7.5]);
+        assert_eq!(
+            speeds("<speed>5.0</speed>", "<speed>7.5</speed>"),
+            vec![5.0, 7.5]
+        );
 
         // Garmin TrackPointExtension v2: <gpxtpx:speed> inside <extensions>
         assert_eq!(

--- a/src-tauri/src/render/chart.rs
+++ b/src-tauri/src/render/chart.rs
@@ -11,6 +11,28 @@ use crate::render::color::to_skia_color;
 use crate::render::template::{CourseMarkerConfig, PlotConfig, PointLabelConfig};
 use crate::render::units;
 
+/// Banded per-segment coloring driven by a second attribute (`color_by`).
+pub struct Banding {
+    /// Color-driving series in display units, aligned with x/y data.
+    pub data: Vec<f64>,
+    /// (upper bound, hex color) sorted ascending; values at or above the last
+    /// bound clamp to it.
+    pub bands: Vec<(f64, String)>,
+    /// Band-color the under-curve fill (non-course plots only).
+    pub fill: bool,
+    /// Band-color the line itself.
+    pub line: bool,
+}
+
+/// Index of the band `v` falls in: first band whose upper bound exceeds `v`,
+/// clamping to the last band (also the NaN fallback).
+fn band_index(bands: &[(f64, String)], v: f64) -> usize {
+    bands
+        .iter()
+        .position(|(max, _)| v < *max)
+        .unwrap_or(bands.len().saturating_sub(1))
+}
+
 /// Pixel bounds of the data area inside a chart surface (excluding margins).
 #[derive(Debug, Clone)]
 pub struct PlotBounds {
@@ -114,6 +136,8 @@ pub struct ChartCache {
     pub line_color: String,
     /// Line width (needed for per-frame past-segment drawing).
     pub line_width: f32,
+    /// Banded coloring by a second attribute (None = single-color plot).
+    pub banding: Option<Banding>,
 }
 
 impl ChartCache {
@@ -122,6 +146,7 @@ impl ChartCache {
         x_data: Vec<f64>,
         y_data: Vec<f64>,
         distance_data: Vec<f64>,
+        color_data: Vec<f64>,
         fonts_dir: &str,
     ) -> Option<Self> {
         if x_data.is_empty() || y_data.is_empty() {
@@ -177,6 +202,22 @@ impl ChartCache {
             (y_min - y_pad, y_max + y_pad)
         };
 
+        // Band thresholds are authored in display units; convert the color
+        // series once so lookups compare like with like.
+        let banding = config.color_by.as_ref().and_then(|cb| {
+            let bands = cb.resolved_bands();
+            if bands.is_empty() || color_data.len() != x_data.len() {
+                return None;
+            }
+            let (conv, _) = units::resolve(cb.attr(), cb.unit.as_deref());
+            Some(Banding {
+                data: color_data.iter().map(|&v| conv.apply(v)).collect(),
+                bands,
+                fill: cb.color_fill(is_course),
+                line: cb.color_line(is_course),
+            })
+        });
+
         let background = render_chart_background(
             surf_w,
             surf_h,
@@ -191,6 +232,7 @@ impl ChartCache {
             },
             config,
             geo.as_ref(),
+            banding.as_ref(),
         );
 
         // Load the point-label typeface once (None when no label configured).
@@ -240,6 +282,7 @@ impl ChartCache {
             future_opacity,
             line_color: config.line_color(),
             line_width: config.line_width(),
+            banding,
         })
     }
 
@@ -398,33 +441,62 @@ impl ChartCache {
         {
             let past_end = frame_idx + 1;
             let past_opacity = self.past_opacity.unwrap_or(1.0);
-            let past_color = to_skia_color(&self.line_color, Some(past_opacity));
-            let mut pb = PathBuilder::new();
-            for (i, (&x, &y)) in self
+            let pts: Vec<Point> = self
                 .x_data
                 .iter()
                 .zip(self.y_data.iter())
                 .take(past_end)
-                .enumerate()
-            {
-                let local_pt = geo.to_pixel(x, y, &self.plot_bounds);
-                let abs_pt = Point::new(
-                    local_pt.x + self.x_offset as f32,
-                    local_pt.y + self.y_offset as f32,
+                .map(|(&x, &y)| {
+                    let local_pt = geo.to_pixel(x, y, &self.plot_bounds);
+                    Point::new(
+                        local_pt.x + self.x_offset as f32,
+                        local_pt.y + self.y_offset as f32,
+                    )
+                })
+                .collect();
+            if let Some(b) = self.banding.as_ref().filter(|b| b.line) {
+                let idx: Vec<usize> = b
+                    .data
+                    .iter()
+                    .take(past_end)
+                    .map(|&v| band_index(&b.bands, v))
+                    .collect();
+                // Bound the opacity layer to the chart area (inflated by the
+                // stroke) so the per-frame layer allocation stays small.
+                let pad = self.line_width;
+                let layer_rect = Rect::from_xywh(
+                    self.x_offset as f32 - pad,
+                    self.y_offset as f32 - pad,
+                    self.plot_bounds.right + 2.0 * pad,
+                    self.plot_bounds.bottom + 2.0 * pad,
                 );
-                if i == 0 {
-                    pb.move_to(abs_pt);
-                } else {
-                    pb.line_to(abs_pt);
+                draw_banded_polyline(
+                    canvas,
+                    &pts,
+                    &idx,
+                    &b.bands,
+                    self.line_width,
+                    past_opacity,
+                    layer_rect,
+                );
+            } else {
+                let past_color = to_skia_color(&self.line_color, Some(past_opacity));
+                let mut pb = PathBuilder::new();
+                for (i, &pt) in pts.iter().enumerate() {
+                    if i == 0 {
+                        pb.move_to(pt);
+                    } else {
+                        pb.line_to(pt);
+                    }
                 }
+                let path = pb.snapshot();
+                let mut paint = Paint::default();
+                paint.set_anti_alias(true);
+                paint.set_color(past_color);
+                paint.set_stroke_width(self.line_width);
+                paint.set_style(PaintStyle::Stroke);
+                canvas.draw_path(&path, &paint);
             }
-            let path = pb.snapshot();
-            let mut paint = Paint::default();
-            paint.set_anti_alias(true);
-            paint.set_color(past_color);
-            paint.set_stroke_width(self.line_width);
-            paint.set_style(PaintStyle::Stroke);
-            canvas.draw_path(&path, &paint);
         }
 
         // 3. Draw static course markers over the route.
@@ -566,6 +638,7 @@ fn render_chart_background(
     bounds: &DataBounds,
     config: &PlotConfig,
     geo: Option<&GeoMapping>,
+    banding: Option<&Banding>,
 ) -> skia_safe::Image {
     let DataBounds {
         x_min,
@@ -616,7 +689,14 @@ fn render_chart_background(
     let line_path = pb.snapshot();
 
     // Draw fill under the curve
-    if let Some(fill_opacity) = config.fill_opacity() {
+    let usable_banding = banding.filter(|b| b.data.len() == x_data.len() && x_data.len() >= 2);
+    if let Some(b) = usable_banding.filter(|b| b.fill) {
+        // Banded fill defaults to fully opaque (TdF profiles are solid).
+        let alpha = config.fill_opacity().unwrap_or(1.0).clamp(0.0, 1.0);
+        if alpha > 0.0 {
+            draw_banded_fill(canvas, plot_bounds, x_data, y_data, b, &to_px, y_min, alpha);
+        }
+    } else if let Some(fill_opacity) = config.fill_opacity() {
         let fill_color_str = config.fill_color();
         let (r, g, b, _) = crate::render::color::parse_hex_color(&fill_color_str);
         let alpha = (fill_opacity.clamp(0.0, 1.0) * 255.0) as u8;
@@ -649,20 +729,288 @@ fn render_chart_background(
     } else {
         None
     };
-    let line_color = to_skia_color(&config.line_color(), split_opacity);
-    let mut line_paint = Paint::default();
-    line_paint.set_anti_alias(true);
-    line_paint.set_color(line_color);
-    line_paint.set_stroke_width(config.line_width());
-    line_paint.set_style(PaintStyle::Stroke);
-    canvas.draw_path(&line_path, &line_paint);
+    if let Some(b) = usable_banding.filter(|b| b.line) {
+        let pts: Vec<Point> = x_data
+            .iter()
+            .zip(y_data.iter())
+            .map(|(&x, &y)| to_px(x, y))
+            .collect();
+        let idx: Vec<usize> = b.data.iter().map(|&v| band_index(&b.bands, v)).collect();
+        let layer_rect = Rect::from_iwh(surf_w, surf_h);
+        draw_banded_polyline(
+            canvas,
+            &pts,
+            &idx,
+            &b.bands,
+            config.line_width(),
+            split_opacity.unwrap_or(1.0),
+            layer_rect,
+        );
+    } else {
+        let line_color = to_skia_color(&config.line_color(), split_opacity);
+        let mut line_paint = Paint::default();
+        line_paint.set_anti_alias(true);
+        line_paint.set_color(line_color);
+        line_paint.set_stroke_width(config.line_width());
+        line_paint.set_style(PaintStyle::Stroke);
+        canvas.draw_path(&line_path, &line_paint);
+    }
 
     surface.image_snapshot()
 }
 
+/// Fill the area under the curve with per-band colors, TdF-profile style.
+///
+/// Samples the curve once per pixel column, groups consecutive columns that
+/// share a band into run polygons, and draws each run extended one column
+/// into both neighbours: the overlap lets the next opaque run cover the
+/// previous run's anti-aliased edge, so band boundaries blend over 1px
+/// instead of leaving a hairline seam. Translucency is applied by drawing
+/// opaque runs inside an alpha layer — overlaps must not double-blend.
+#[allow(clippy::too_many_arguments)]
+fn draw_banded_fill(
+    canvas: &Canvas,
+    plot_bounds: &PlotBounds,
+    x_data: &[f64],
+    y_data: &[f64],
+    banding: &Banding,
+    to_px: &dyn Fn(f64, f64) -> Point,
+    y_base: f64,
+    alpha: f32,
+) -> Option<()> {
+    let n = y_data.len();
+    let cols_n = plot_bounds.width().floor() as i32;
+    if n < 2 || cols_n < 1 {
+        return None;
+    }
+    let base_y = to_px(*x_data.first()?, y_base).y;
+
+    // Per pixel column: (x px, curve y px, band index).
+    let cols: Vec<(f32, f32, usize)> = (0..=cols_n)
+        .map(|c| {
+            let pos = c as f64 / cols_n as f64 * (n - 1) as f64;
+            let i = pos.floor() as usize;
+            let j = (i + 1).min(n - 1);
+            let f = pos - i as f64;
+            let x = x_data[i] + (x_data[j] - x_data[i]) * f;
+            let y = y_data[i] + (y_data[j] - y_data[i]) * f;
+            let v = banding.data[i] + (banding.data[j] - banding.data[i]) * f;
+            let pt = to_px(x, y);
+            (pt.x, pt.y, band_index(&banding.bands, v))
+        })
+        .collect();
+
+    let layered = alpha < 1.0;
+    if layered {
+        canvas.save_layer_alpha_f(
+            Rect::from_ltrb(
+                plot_bounds.left,
+                plot_bounds.top,
+                plot_bounds.right,
+                plot_bounds.bottom,
+            ),
+            alpha,
+        );
+    }
+    let mut run_start = 0usize;
+    while run_start < cols.len() {
+        let band = cols[run_start].2;
+        let mut run_end = run_start;
+        while run_end + 1 < cols.len() && cols[run_end + 1].2 == band {
+            run_end += 1;
+        }
+        let draw_start = run_start.saturating_sub(1);
+        let draw_end = (run_end + 1).min(cols.len() - 1);
+        let mut pb = PathBuilder::new();
+        pb.move_to(Point::new(cols[draw_start].0, base_y));
+        for col in &cols[draw_start..=draw_end] {
+            pb.line_to(Point::new(col.0, col.1));
+        }
+        pb.line_to(Point::new(cols[draw_end].0, base_y));
+        pb.close();
+
+        let mut paint = Paint::default();
+        paint.set_anti_alias(true);
+        paint.set_color(to_skia_color(&banding.bands[band].1, None));
+        paint.set_style(PaintStyle::Fill);
+        canvas.draw_path(&pb.snapshot(), &paint);
+        run_start = run_end + 1;
+    }
+    if layered {
+        canvas.restore();
+    }
+    Some(())
+}
+
+/// Stroke a polyline in per-band colors. Segment i takes the band of its
+/// start point; consecutive same-band segments are stroked as one path,
+/// sharing the boundary point with the next run so the line stays continuous
+/// (round caps/joins hide the joint). Translucency is applied via an alpha
+/// layer so the overlapping caps at run joints don't double-blend.
+fn draw_banded_polyline(
+    canvas: &Canvas,
+    pts: &[Point],
+    band_idx: &[usize],
+    bands: &[(f64, String)],
+    width: f32,
+    alpha: f32,
+    layer_rect: Rect,
+) {
+    if pts.len() < 2 || alpha <= 0.0 {
+        return;
+    }
+    let layered = alpha < 1.0;
+    if layered {
+        canvas.save_layer_alpha_f(layer_rect, alpha);
+    }
+    let n_seg = pts.len() - 1;
+    let mut seg = 0usize;
+    while seg < n_seg {
+        let band = band_idx[seg];
+        let mut end = seg;
+        while end + 1 < n_seg && band_idx[end + 1] == band {
+            end += 1;
+        }
+        let mut pb = PathBuilder::new();
+        pb.move_to(pts[seg]);
+        for pt in &pts[seg + 1..=end + 1] {
+            pb.line_to(*pt);
+        }
+        let mut paint = Paint::default();
+        paint.set_anti_alias(true);
+        paint.set_color(to_skia_color(&bands[band].1, None));
+        paint.set_stroke_width(width);
+        paint.set_style(PaintStyle::Stroke);
+        paint.set_stroke_cap(skia_safe::PaintCap::Round);
+        paint.set_stroke_join(skia_safe::PaintJoin::Round);
+        canvas.draw_path(&pb.snapshot(), &paint);
+        seg = end + 1;
+    }
+    if layered {
+        canvas.restore();
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::format_point_label;
+    use super::{ChartCache, band_index, draw_banded_polyline, format_point_label};
+    use skia_safe::{Color, ISize, ImageInfo, Point, Rect};
+
+    fn bands() -> Vec<(f64, String)> {
+        vec![
+            (0.0, "#3b82f6".to_string()),
+            (4.0, "#22c55e".to_string()),
+            (f64::INFINITY, "#dc2626".to_string()),
+        ]
+    }
+
+    #[test]
+    fn band_index_picks_first_band_above_value_and_clamps() {
+        let b = bands();
+        assert_eq!(band_index(&b, -5.0), 0);
+        assert_eq!(band_index(&b, 0.0), 1); // bounds are exclusive upper
+        assert_eq!(band_index(&b, 3.9), 1);
+        assert_eq!(band_index(&b, 4.0), 2);
+        assert_eq!(band_index(&b, 99.0), 2);
+        assert_eq!(band_index(&b, f64::NAN), 2); // NaN clamps to last
+    }
+
+    /// Read one BGRA pixel from a Skia image.
+    fn pixel(img: &skia_safe::Image, x: i32, y: i32) -> (u8, u8, u8, u8) {
+        let info = ImageInfo::new(
+            ISize::new(1, 1),
+            skia_safe::ColorType::BGRA8888,
+            skia_safe::AlphaType::Premul,
+            None,
+        );
+        let mut buf = [0u8; 4];
+        assert!(img.read_pixels(
+            &info,
+            &mut buf,
+            4,
+            (x, y),
+            skia_safe::image::CachingHint::Disallow,
+        ));
+        (buf[0], buf[1], buf[2], buf[3]) // B, G, R, A
+    }
+
+    #[test]
+    fn banded_fill_colors_under_curve_by_band() {
+        // Elevation ramp colored by a gradient series: first half 2.0 (green
+        // band of the built-in defaults), second half 8.0 (orange band).
+        let config: crate::render::template::PlotConfig =
+            serde_json::from_value(serde_json::json!({
+                "id": "plot-0",
+                "type": "plot",
+                "value": "elevation",
+                "x": 0, "y": 0, "width": 400, "height": 150,
+                "color_by": { "value": "gradient" }
+            }))
+            .unwrap();
+        let n = 100;
+        let x: Vec<f64> = (0..n).map(|i| i as f64).collect();
+        let y: Vec<f64> = (0..n).map(|i| i as f64).collect();
+        let grade: Vec<f64> = (0..n).map(|i| if i < n / 2 { 2.0 } else { 8.0 }).collect();
+        let cache = ChartCache::build(&config, x, y, Vec::new(), grade, "/nonexistent").unwrap();
+        assert!(cache.banding.is_some());
+
+        // Deep under the curve on each half. Defaults: 2% → #22c55e, 8% → #f97316.
+        assert_eq!(pixel(&cache.background, 100, 140), (0x5e, 0xc5, 0x22, 0xff));
+        assert_eq!(pixel(&cache.background, 300, 140), (0x16, 0x73, 0xf9, 0xff));
+        // Above the curve stays transparent.
+        assert_eq!(pixel(&cache.background, 100, 10), (0, 0, 0, 0));
+    }
+
+    #[test]
+    fn banded_polyline_strokes_runs_and_applies_layer_alpha() {
+        let info = ImageInfo::new(
+            ISize::new(100, 100),
+            skia_safe::ColorType::BGRA8888,
+            skia_safe::AlphaType::Premul,
+            None,
+        );
+        let mut surface = skia_safe::surfaces::raster(&info, None, None).unwrap();
+        surface.canvas().clear(Color::TRANSPARENT);
+        let pts = [
+            Point::new(10.0, 50.0),
+            Point::new(50.0, 50.0),
+            Point::new(90.0, 50.0),
+        ];
+        // Segment bands: first green (idx 1), second red (idx 2).
+        draw_banded_polyline(
+            surface.canvas(),
+            &pts,
+            &[1, 2],
+            &bands(),
+            10.0,
+            1.0,
+            Rect::from_iwh(100, 100),
+        );
+        let img = surface.image_snapshot();
+        assert_eq!(pixel(&img, 30, 50), (0x5e, 0xc5, 0x22, 0xff)); // #22c55e
+        assert_eq!(pixel(&img, 70, 50), (0x26, 0x26, 0xdc, 0xff)); // #dc2626
+
+        // Translucent variant: alpha applied once via the layer, even where
+        // the two runs' round caps overlap at the shared point.
+        surface.canvas().clear(Color::TRANSPARENT);
+        draw_banded_polyline(
+            surface.canvas(),
+            &pts,
+            &[1, 2],
+            &bands(),
+            10.0,
+            0.5,
+            Rect::from_iwh(100, 100),
+        );
+        let img = surface.image_snapshot();
+        let (_, _, _, a_mid) = pixel(&img, 30, 50);
+        let (_, _, _, a_joint) = pixel(&img, 50, 50);
+        assert!((a_mid as i32 - 128).abs() <= 2, "alpha was {a_mid}");
+        assert!(
+            (a_joint as i32 - 128).abs() <= 2,
+            "joint alpha was {a_joint} (double-blend?)"
+        );
+    }
 
     #[test]
     fn elevation_metric_and_imperial_match_screenshot_format() {

--- a/src-tauri/src/render/frame.rs
+++ b/src-tauri/src/render/frame.rs
@@ -346,7 +346,12 @@ impl OverlayElement for PlotConfig {
         } else {
             Vec::new()
         };
-        ChartCache::build(self, x_data, y_data, distance_data, fonts_dir)
+        let color_data = self
+            .color_by
+            .as_ref()
+            .map(|cb| activity.plot_data(cb.attr()).1)
+            .unwrap_or_default();
+        ChartCache::build(self, x_data, y_data, distance_data, color_data, fonts_dir)
     }
 
     fn measure(&self, _ctx: &ElementCtx, _frame_idx: usize) -> Option<ElementBounds> {
@@ -2088,6 +2093,128 @@ fn load_svg_image(path: &std::path::Path) -> Option<skia_safe::Image> {
 #[cfg(test)]
 mod tests {
     use crate::render::template::Template;
+
+    /// End-to-end `color_by`: banded elevation fill, banded line plot, and a
+    /// banded course line (with past/future split) render through
+    /// SceneCache::build → render_frame, each producing several distinct band
+    /// colors inside its rect. Set CYCLEMETRY_TEST_DUMP=<dir> to write a PNG.
+    #[test]
+    fn color_by_renders_banded_plots_end_to_end() {
+        use super::{SceneCache, render_frame};
+        use crate::render::activity::Activity;
+        use crate::render::template::DEFAULT_GRADIENT_BANDS;
+
+        let mut activity = Activity::synthetic(600);
+        // Widen the synthetic gradient (±3%) so the sweep crosses most of the
+        // default bands (−12%…12%).
+        activity.gradient = (0..600).map(|i| 12.0 * (i as f64 / 40.0).cos()).collect();
+
+        let raw = serde_json::json!({
+            "scene": { "width": 1280, "height": 720 },
+            "elements": [
+                { "type": "rect", "id": "bg", "x": 0, "y": 0, "width": 1280, "height": 720,
+                  "color": "#18181b" },
+                { "type": "plot", "id": "profile", "value": "elevation",
+                  "x": 40, "y": 420, "width": 560, "height": 240,
+                  "line": { "color": "#ffffff", "width": 3 },
+                  "color_by": { "value": "gradient" } },
+                { "type": "plot", "id": "line-plot", "value": "elevation",
+                  "x": 680, "y": 420, "width": 560, "height": 240,
+                  "line": { "width": 6 },
+                  "color_by": { "value": "gradient", "mode": "line" } },
+                { "type": "plot", "id": "course", "value": "course",
+                  "x": 40, "y": 40, "width": 560, "height": 320,
+                  "line": { "width": 8, "past_opacity": 1.0, "future_opacity": 0.25 },
+                  "point": { "color": "#ffffff", "weight": 300 },
+                  "color_by": { "value": "gradient" } }
+            ]
+        });
+        let template = Template::from_value(raw).unwrap();
+        let cache = SceneCache::build(&activity, &template, "/nonexistent", &[]).unwrap();
+        let frame = render_frame(300, &cache, &activity, &template, None, None);
+
+        // Count which band colors appear (exact matches only — interiors of
+        // opaque banded draws) within a rect of the BGRA frame.
+        let bands_in_rect = |x0: usize, y0: usize, w: usize, h: usize| -> usize {
+            DEFAULT_GRADIENT_BANDS
+                .iter()
+                .filter(|(_, hex)| {
+                    let (r, g, b, _) = crate::render::color::parse_hex_color(hex);
+                    (y0..y0 + h).any(|y| {
+                        (x0..x0 + w).any(|x| {
+                            let i = (y * 1280 + x) * 4;
+                            frame[i] == b && frame[i + 1] == g && frame[i + 2] == r
+                        })
+                    })
+                })
+                .count()
+        };
+        assert!(bands_in_rect(40, 420, 560, 240) >= 4, "banded fill");
+        assert!(bands_in_rect(680, 420, 560, 240) >= 4, "banded line");
+        // Course: only the traveled half is opaque (future is at 0.25 alpha).
+        assert!(bands_in_rect(40, 40, 560, 320) >= 3, "banded course line");
+
+        if let Ok(dir) = std::env::var("CYCLEMETRY_TEST_DUMP") {
+            let info = skia_safe::ImageInfo::new(
+                skia_safe::ISize::new(1280, 720),
+                skia_safe::ColorType::BGRA8888,
+                skia_safe::AlphaType::Premul,
+                None,
+            );
+            let data = skia_safe::Data::new_copy(&frame);
+            let img = skia_safe::images::raster_from_data(&info, data, 1280 * 4).unwrap();
+            let png = img
+                .encode(None, skia_safe::EncodedImageFormat::PNG, None)
+                .unwrap();
+            std::fs::write(format!("{dir}/color_by_e2e.png"), png.as_bytes()).unwrap();
+        }
+    }
+
+    /// Mirrors the native_demo preview path when the user drags the timeline
+    /// trim: scaled template parse → sample_for_scene over a changed window →
+    /// SceneCache::build → render_frame, with color_by plots present.
+    #[test]
+    fn time_range_change_rebuilds_color_by_preview() {
+        use super::{SceneCache, render_frame};
+        use crate::render::activity::Activity;
+
+        let source = Activity::synthetic(600);
+        let raw = serde_json::json!({
+            "scene": { "width": 3840, "height": 2160, "start": 60.0, "end": 240.0 },
+            "elements": [
+                { "type": "plot", "id": "profile", "value": "elevation",
+                  "x": 100, "y": 1200, "width": 1600, "height": 700,
+                  "line": { "color": "#ffffff", "width": 8 },
+                  "point": { "color": "#ffffff", "weight": 900 },
+                  "color_by": { "value": "gradient" } },
+                { "type": "plot", "id": "course", "value": "course",
+                  "x": 2000, "y": 200, "width": 1500, "height": 900,
+                  "line": { "width": 20, "past_opacity": 1.0, "future_opacity": 0.3 },
+                  "color_by": { "value": "gradient", "bands": [
+                      { "max": 0, "color": "#3b82f6" }, { "color": "#dc2626" } ] } }
+            ]
+        });
+
+        // The preview re-runs this whole flow for every new trim window.
+        for (start, end) in [(60.0, 240.0), (10.0, 590.0), (300.0, 302.0), (0.0, 600.0)] {
+            let mut config = raw.clone();
+            config["scene"]["start"] = serde_json::json!(start);
+            config["scene"]["end"] = serde_json::json!(end);
+            let mut template =
+                crate::render::template::Template::from_value_scaled(config, Some((1280, 720)))
+                    .unwrap();
+            template.scene.fps = 10;
+            template.scene.target_duration = None;
+            let activity = source.sample_for_scene(&template.scene, true).unwrap();
+            let cache = SceneCache::build(&activity, &template, "/nonexistent", &[]).unwrap();
+            assert_eq!(cache.charts.len(), 2, "window {start}..{end}");
+            let last = activity.data_len().saturating_sub(1);
+            for idx in [0, last / 2, last] {
+                let frame = render_frame(idx, &cache, &activity, &template, None, None);
+                assert_eq!(frame.len(), 1280 * 720 * 4);
+            }
+        }
+    }
 
     /// Unified model: explicit `scene.layers` ids drive draw order; elements
     /// not listed fall back to array order after the listed ones.

--- a/src-tauri/src/render/template.rs
+++ b/src-tauri/src/render/template.rs
@@ -391,6 +391,10 @@ pub struct PlotConfig {
     pub opacity: Option<f32>,
     pub line: Option<LineConfig>,
     pub fill: Option<FillConfig>,
+    /// Color plot segments by a second attribute (e.g. gradient) using
+    /// ordered value bands — Tour-de-France-style climb profiles.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color_by: Option<ColorByConfig>,
     pub margin: Option<f64>,
     /// Single position marker for the current-value dot (preferred schema).
     pub point: Option<PointConfig>,
@@ -418,6 +422,80 @@ pub struct LineConfig {
 pub struct FillConfig {
     pub opacity: Option<f32>,
     pub color: Option<String>,
+}
+
+/// Built-in gradient bands (percent): descent, then TdF-style climb
+/// categories. Used when a gradient `color_by` has no explicit bands.
+pub const DEFAULT_GRADIENT_BANDS: &[(f64, &str)] = &[
+    (0.0, "#3b82f6"),
+    (4.0, "#22c55e"),
+    (7.0, "#eab308"),
+    (10.0, "#f97316"),
+    (14.0, "#dc2626"),
+    (f64::INFINITY, "#7f1d1d"),
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ColorByConfig {
+    /// Attribute driving the color (default "gradient").
+    pub value: Option<String>,
+    /// Unit token for band thresholds (e.g. "mph" to author speed bands in
+    /// mph). Absent = the attribute's metric display unit (km/h, °C, m).
+    pub unit: Option<String>,
+    /// What gets band-colored: "fill" (under-curve), "line", or "both".
+    /// Default "fill". Course plots always color the route line only.
+    pub mode: Option<String>,
+    /// Ordered color bands; a value falls in the first band whose `max`
+    /// exceeds it. Absent/empty falls back to the built-in gradient bands
+    /// (non-gradient attributes require explicit bands).
+    pub bands: Option<Vec<ColorBand>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ColorBand {
+    /// Upper bound (exclusive) in display units. Absent = catch-all top band.
+    pub max: Option<f64>,
+    pub color: String,
+}
+
+impl ColorByConfig {
+    pub fn attr(&self) -> &str {
+        self.value
+            .as_deref()
+            .unwrap_or(crate::render::activity::ATTR_GRADIENT)
+    }
+
+    /// Whether the under-curve fill is band-colored. Never for course plots,
+    /// which have no fill.
+    pub fn color_fill(&self, is_course: bool) -> bool {
+        !is_course && !matches!(self.mode.as_deref(), Some("line"))
+    }
+
+    /// Whether the line is band-colored. Always for course plots (the route
+    /// line is the only paintable surface), else when mode is "line"/"both".
+    pub fn color_line(&self, is_course: bool) -> bool {
+        is_course || matches!(self.mode.as_deref(), Some("line") | Some("both"))
+    }
+
+    /// Bands as (upper bound, color) sorted ascending. Values above the last
+    /// bound clamp to it. Empty when no bands apply (disables the feature).
+    pub fn resolved_bands(&self) -> Vec<(f64, String)> {
+        match &self.bands {
+            Some(bands) if !bands.is_empty() => {
+                let mut out: Vec<(f64, String)> = bands
+                    .iter()
+                    .map(|b| (b.max.unwrap_or(f64::INFINITY), b.color.clone()))
+                    .collect();
+                out.sort_by(|a, b| a.0.total_cmp(&b.0));
+                out
+            }
+            _ if self.attr() == crate::render::activity::ATTR_GRADIENT => DEFAULT_GRADIENT_BANDS
+                .iter()
+                .map(|&(max, color)| (max, color.to_string()))
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -917,6 +995,45 @@ fn merge_scene_into_item(scene: &serde_json::Value, item: &mut serde_json::Value
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn color_by_defaults_to_gradient_bands_sorted() {
+        let cb: ColorByConfig = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(cb.attr(), "gradient");
+        let bands = cb.resolved_bands();
+        assert_eq!(bands.len(), DEFAULT_GRADIENT_BANDS.len());
+        assert!(bands.windows(2).all(|w| w[0].0 <= w[1].0));
+        assert_eq!(bands.last().unwrap().0, f64::INFINITY);
+        // Default mode: fill for profiles, line for course.
+        assert!(cb.color_fill(false) && !cb.color_line(false));
+        assert!(!cb.color_fill(true) && cb.color_line(true));
+    }
+
+    #[test]
+    fn color_by_explicit_bands_sort_and_catch_all() {
+        let cb: ColorByConfig = serde_json::from_value(serde_json::json!({
+            "value": "power",
+            "mode": "both",
+            "bands": [
+                { "color": "#111111" },
+                { "max": 300, "color": "#222222" },
+                { "max": 150, "color": "#333333" }
+            ]
+        }))
+        .unwrap();
+        let bands = cb.resolved_bands();
+        assert_eq!(bands[0], (150.0, "#333333".to_string()));
+        assert_eq!(bands[1], (300.0, "#222222".to_string()));
+        assert_eq!(bands[2].0, f64::INFINITY);
+        assert!(cb.color_fill(false) && cb.color_line(false));
+    }
+
+    #[test]
+    fn color_by_non_gradient_without_bands_disables() {
+        let cb: ColorByConfig =
+            serde_json::from_value(serde_json::json!({ "value": "power" })).unwrap();
+        assert!(cb.resolved_bands().is_empty());
+    }
 
     /// The bundled ride-summary flyover template must always parse through the
     /// real deserializer and carry the time-lapse + running-metric wiring, so a


### PR DESCRIPTION
<img width="1013" height="681" alt="image" src="https://github.com/user-attachments/assets/8e3388a8-7be6-4b67-b01e-32ba1cc0fb0f" />

While working on a video project I was looking for the ability to add an elevation profile that included the grade via color. I extended this idea into a generic addition to the chart and map elements, allowing you to use a second metric to apply colors to the line or area under the line. During testing I was having performance issues when changing the range on the timeline and the first commit of this pull request was related to that.

This was just a feature I needed for a video but I wanted to go ahead and share the code back if you think it would be of interest to anyone else. The performance change especially feels pretty intrusive which is why I split that off into its own commit. If there is another way you think this should work I can change it around or just close it out if this is too much to review.

Thanks for making this.